### PR TITLE
Fixed paths to Chrome and Chromium browsers on Linux

### DIFF
--- a/flexx/webruntime/chromeapp.py
+++ b/flexx/webruntime/chromeapp.py
@@ -25,7 +25,9 @@ def get_chrome_exe():
         paths.append(os.path.expanduser("~\\AppData\\Local\\Google\\Chrome\\chrome.exe"))
         paths.append(os.path.expanduser("~\\Local Settings\\Application Data\\Google\\Chrome\\chrome.exe"))  # xp
     elif sys.platform.startswith('linux'):
-        paths.append('/usr/lib/google-chrome/google-chrome')
+        paths.append('/usr/bin/google-chrome-stable')
+        paths.append('/usr/bin/google-chrome-beta')
+        paths.append('/usr/bin/google-chrome-dev')
     elif sys.platform.startswith('darwin'):
         paths.append('/Applications/Chrome.app')
     
@@ -52,7 +54,7 @@ def get_chromium_exe():
         paths.append(os.path.expanduser("~\\Local Settings\\Application Data\\Chromium\\chrome.exe"))  # xp
        
     elif sys.platform.startswith('linux'):
-        paths.append('/usr/lib/chromium-browser/chromium-browser')
+        paths.append('/usr/bin/chromium')
     elif sys.platform.startswith('darwin'):
         paths.append('/Applications/Chromium.app')
     


### PR DESCRIPTION
I posted this on the issue tracker but I realized despite never having made a pull request before, I knew enough about git to figure it out so I made one.

The links to Chrome and Chromium on Linux are currently pointing to /usr/lib/google-chrome/google-chrome and /usr/lib/chromium-browser/chromium-browser.

The correct paths on modern distros to Chrome and Chromium are /usr/bin/google-chrome-$CHANNEL and /usr/bin/chromium respectively.

Tested on Arch Linux with Google Chrome stable channel.

closes #29