### PR TITLE
a few small fixes

### DIFF
--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -253,6 +253,7 @@ class WSHandler(tornado.websocket.WebSocketHandler):
         We now have a very basic protocol for receiving messages,
         we should at some point define a real formalized protocol.
         """
+        self._pongtime = time.time()
         if self._session is None:
             if message.startswith('hiflexx '):
                 session_id = message.split(' ', 1)[1].strip()

--- a/flexx/react/pyscript.py
+++ b/flexx/react/pyscript.py
@@ -52,7 +52,7 @@ class HasSignalsJS:
         def setter():
             raise ValueError(name + ' is not settable')
         obj[private_name] = initial
-        opts = {'enumerable': True, 'configurable': False,
+        opts = {'enumerable': True, 'configurable': True,  # i.e. overloadable
                 'get': getter, 'set': setter}
         Object.defineProperty(obj, name, opts)
     

--- a/flexx/react/tests/test_both.py
+++ b/flexx/react/tests/test_both.py
@@ -147,11 +147,12 @@ def test_hassignal_attributes(Name):
         s.r.append(s.first_name.value)
     except Exception:
         s.r.append('err')
-    # cannot delete signals
-    try:
-        del s.first_name
-    except Exception:
-        pass  # on Python it raises, on JS it ignores
+    # cannot delete signals on Python, but on JS we can, because
+    # configurable = true to allow overloading signals.
+    # try:
+    #     del s.first_name
+    # except Exception:
+    #     pass  # on Python it raises, on JS it ignores
     s.r.append(s.first_name.value)
     return s.r
 

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -394,8 +394,9 @@ class Widget(Model):
                 if self.node.parentNode is not None:  # detachWidget not enough
                     self.node.parentNode.removeChild(self.node)
                 phosphor.widget.attachWidget(self.p, el)
-                p = self.p
-                window.addEventListener('resize', lambda: p.update())
+                that = self
+                window.addEventListener('resize', lambda: (that.p.update(), 
+                                                           that._check_real_size()))
             if id == 'body':
                 self.node.classList.add('flx-main-widget')
         
@@ -408,7 +409,7 @@ class Widget(Model):
                 return undefined
             if not (new_parent is None or new_parent.__signals__):
                 raise ValueError('parent must be a widget or None')
-            
+                
             if old_parent is undefined:
                 return new_parent
             


### PR DESCRIPTION
* Pong is also triggered when receiving other messages. This way, if the communication is very busy, the connection won't time out.
* Allow signals to be overloaded.
* Changing widget container triggers resize check.