### PR TITLE
Improved support for debugging JS

### DIFF
--- a/flexx/app/clientcore.py
+++ b/flexx/app/clientcore.py
@@ -147,14 +147,15 @@ class FlexxJS:
             if flexx.ws is not None:
                 flexx.ws.send("ERROR " + msg)
         def on_error(self, evt):
-            msg = evt
-            if evt.message and evt.lineno:  # message, url, linenumber (not in nodejs)
-                msg = "On line %i in %s:\n%s" % (evt.lineno, evt.filename, evt.message)
-            elif evt.stack:
-                msg = evt.stack
-            if flexx.ws is not None:
-                flexx.ws.send("ERROR " + msg)
-        
+            msg = evt.message
+            if evt.error.stack:
+                stack = [x.replace('@', ' @ ') if '.js' in x else x.split('@')[0]
+                         for x in evt.error.stack.splitlines()]
+                msg += '\n' + '\n'.join(stack)
+            elif evt.message and evt.lineno:  # message, url, linenumber (not in nodejs)
+                msg += "\nIn %s:%i" % (evt.filename, evt.lineno)
+            console.error(msg)
+            evt.preventDefault()  # Don't do the standard error 
         # Set new versions
         console.log = log
         console.info = info

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -169,6 +169,27 @@ class MainHandler(tornado.web.RequestHandler):
                     self.write(session.get_page().encode())
                 else:
                     self.write('No app %r is currently hosted.' % app_name)
+            elif file_name and '.js:' in file_name:
+                # Request for a view of a JS source file at a certain line, redirect
+                fname, where = file_name.split(':')[:2]
+                self.redirect('/%s/%s.debug%s#L%s' % (app_name, fname, where, where))
+            elif file_name and '.debug' in file_name:
+                # Show JS source file at a certain line
+                fname, lineno = file_name.split('.debug', 1)
+                try:
+                    res = assets.load_asset(fname)
+                except (IOError, IndexError):
+                    self.write('invalid resource: %s' % fname)
+                else:
+                    lines = ['<html><head><style>%s</style></head><body>' % 
+                             "pre {display:inline} #L%s {background:#cca;}" % lineno]
+                    for i, line in enumerate(res.decode().splitlines()):
+                        table = {ord('&'): '&amp;', ord('<'): '&lt;', ord('>'): '&gt;'}
+                        line = line.translate(table).replace('\t', '    ')
+                        lines.append('<a id="L%i">%i<pre>  %s</pre></a><br />' %
+                                     (i+1, i+1, line))
+                    lines.append('</body></html>')
+                    self.write('\n'.join(lines))
             elif file_name:
                 # A resource, e.g. js/css/icon
                 if file_name.endswith('.css'):

--- a/flexx/react/pyscript.py
+++ b/flexx/react/pyscript.py
@@ -6,7 +6,7 @@ import json
 
 from ..pyscript import py2js as py2js_
 from ..pyscript.parser2 import get_class_definition
-from ..pyscript.stubs import undefined, console, Object, Date
+from ..pyscript.stubs import undefined, Object, Date
 
 from .signals import Signal, SourceSignal
 
@@ -164,13 +164,14 @@ class HasSignalsJS:
             return False  # no error
         
         def _save_update():
-            try:
-                selff()
-            except SignalValueError:  # noqa
-                pass
-            except Exception as err:
-                #print('Error updating signal:', err.stack)
-                console.error('Error updating signal: ' + err)
+            """
+            try {
+                selff();
+            } catch(err) {
+                if (err instanceof Error && err.name === "SignalValueError") {
+                } else {throw err;}
+            }
+            """
         
         def _set_value(value):
             if value is undefined:


### PR DESCRIPTION
When an error occurs while updating a signal (which is a common place where errors occur if you're writing new code), the report no includes a trace. Also made that the links in the trace are clickable in Firefox (Chrome already opens them in the dev console).