### PR TITLE
Prevent Model class name clashes

### DIFF
--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -323,6 +323,15 @@ class SessionAssets:
             if cls2 not in self._known_classes:
                 self.register_model_class(cls2)
         
+        # Make sure that no two models have the same name, or we get problems
+        # that are difficult to debug.
+        same_name = [c for c in self._known_classes if c.__name__ == cls.__name__]
+        if same_name:
+            same_name.append(cls)
+            raise RuntimeError('Cannot have multiple Model classes with the '
+                               'same name: %r' % same_name)
+        
+        logging.info('Registering Model class %r' % cls.__name__)
         self._known_classes.add(cls)
         
         # Check if cls is covered by our assets

--- a/flexx/app/session.py
+++ b/flexx/app/session.py
@@ -42,7 +42,7 @@ class AppManager(object):
         pending, connected = [], []
         if name in self._proxies and cls is not self._proxies[name][0]:
             oldCls, pending, connected = self._proxies[name]
-            logging.info('Re-registering app class %r' % name)
+            logging.warn('Re-registering app class %r' % name)
             #raise ValueError('App with name %r already registered' % name)
         self._proxies[name] = cls, pending, connected
     

--- a/flexx/pyscript/stdlib.py
+++ b/flexx/pyscript/stdlib.py
@@ -785,8 +785,8 @@ IMPORTS['sys'] = {}
 
 IMPORTS['sys'] = None  # mark sys as a module
 IMPORTS['sys.version_info'] = "[%s]" % ', '.join([str(x) for x in sys.version_info[:3]])
-IMPORTS['sys.version'] = "%r" % ('.'.join([str(x) for x in sys.version_info[:3]])
-                                    + ' [PyScript]')
+IMPORTS['sys.version'] = "%r" % ('.'.join([str(x) for x in sys.version_info[:3]]) +
+                                 ' [PyScript]')
 IMPORTS['sys.path'] = "[]"
 
 IMPORTS['time'] = None  # mark time as a module

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,10 +23,12 @@
 # E302 expected 2 blank lines, found 1
 # E303 too many blank lines
 # E402 module level import not at top of file
+# E266 too many leading '#' for block comment
+# E731 do not assign a lambda expression, use a def
 
 exclude: test_*.py,exp/*,docs/*,build/*,dist/*,flexx/lui/*,python_sample*.py,test.py
 
-ignore: W291,W293,E123,E124,E126,E127,E203,E225,E226,E265,E301,E302,E303,E402
+ignore: W291,W293,E123,E124,E126,E127,E203,E225,E226,E265,E301,E302,E303,E402,E266,E731
 
 max-line-length: 88
 


### PR DESCRIPTION
Because you can get nasty bugs otherwise.