### PR TITLE
Change asset order to allow overriding Phosphor default styles

### DIFF
--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -32,10 +32,10 @@ INDEX = """<!doctype html>
 <head>
     <meta charset="utf-8">
     <title>Flexx UI</title>
-    
-CSS-HOOK
 
 JS-HOOK
+    
+CSS-HOOK
 
 </head>
 

--- a/flexx/ui/widgets/_label.py
+++ b/flexx/ui/widgets/_label.py
@@ -35,8 +35,16 @@ class Label(Widget):
     """ Widget to show text/html.
     """
     
-    CSS = ".flx-Label { border: 0px solid #454; }"
-
+    CSS = """
+        .flx-Label {
+            border: 0px solid #454;
+            /* phosphor sets this to none */
+            user-select: text;
+            -moz-user-select: text;
+            -webkit-user-select: text;
+            -ms-user-select: text;
+        }"""
+    
     @react.input
     def text(v=''):
         """ The text on the label.


### PR DESCRIPTION
Could not reset `user-select: none` for label widgets.