### PR TITLE
Pyscript improvement for using foo = x or y

### DIFF
--- a/flexx/pyscript/parser1.py
+++ b/flexx/pyscript/parser1.py
@@ -324,19 +324,23 @@ class Parser1(Parser0):
         name = stdlib.FUNCTION_PREFIX + 'truthy'
         eq_name = stdlib.FUNCTION_PREFIX + 'equals'
         test = ''.join(self.parse(node))
-        if (((name + '(') in test) or test.endswith('.length') or test.isnumeric() or 
-                                      test.startswith('!') or
-                                      test == 'true' or test == 'false' or
-                                      test.count('==') or test.count(eq_name) or
-                                      test == '"this_is_js()"' or
-                                      test.startswith(returning_bool)):
+        if (        test.endswith('.length') or test.isnumeric() or 
+                    test.startswith('!') or
+                    test == 'true' or test == 'false' or
+                    test.count('==') or test.count(eq_name) or
+                    test == '"this_is_js()"' or
+                    (test.startswith(returning_bool) and '||' not in test)):
             return unify(test)
         else:
             return self.use_std_function('truthy', [test])
     
     def parse_BoolOp(self, node):
         op = ' %s ' % self.BOOL_OP[node.op]
-        values = [unify(self._wrap_truthy(val)) for val in node.value_nodes]
+        if node.op.lower() == 'or':  # allow foo = bar or []
+            values = [unify(self._wrap_truthy(val)) for val in node.value_nodes[:-1]]
+            values += [unify(self.parse(node.value_nodes[-1]))]
+        else:
+            values = [unify(self._wrap_truthy(val)) for val in node.value_nodes]
         return op.join(values)
     
     def parse_Compare(self, node):

--- a/flexx/pyscript/parser1.py
+++ b/flexx/pyscript/parser1.py
@@ -323,11 +323,11 @@ class Parser1(Parser0):
         """ Wraps an operation in a truthy call, unless its not necessary. """
         eq_name = stdlib.FUNCTION_PREFIX + 'equals'
         test = ''.join(self.parse(node))
-        if (True or test.endswith('.length') or test.startswith('!') or
-                    test.isnumeric() or test == 'true' or test == 'false' or
-                    test.count('==') or test.count(eq_name) or
-                    test == '"this_is_js()"' or
-                    (test.startswith(returning_bool) and '||' not in test)):
+        if (False or test.endswith('.length') or test.startswith('!') or
+                     test.isnumeric() or test == 'true' or test == 'false' or
+                     test.count('==') or test.count(eq_name) or
+                     test == '"this_is_js()"' or
+                     (test.startswith(returning_bool) and '||' not in test)):
             return unify(test)
         else:
             return self.use_std_function('truthy', [test])

--- a/flexx/pyscript/parser1.py
+++ b/flexx/pyscript/parser1.py
@@ -321,12 +321,10 @@ class Parser1(Parser0):
     
     def _wrap_truthy(self, node):
         """ Wraps an operation in a truthy call, unless its not necessary. """
-        name = stdlib.FUNCTION_PREFIX + 'truthy'
         eq_name = stdlib.FUNCTION_PREFIX + 'equals'
         test = ''.join(self.parse(node))
-        if (        test.endswith('.length') or test.isnumeric() or 
-                    test.startswith('!') or
-                    test == 'true' or test == 'false' or
+        if (True or test.endswith('.length') or test.startswith('!') or
+                    test.isnumeric() or test == 'true' or test == 'false' or
                     test.count('==') or test.count(eq_name) or
                     test == '"this_is_js()"' or
                     (test.startswith(returning_bool) and '||' not in test)):

--- a/flexx/pyscript/tests/test_parser1.py
+++ b/flexx/pyscript/tests/test_parser1.py
@@ -215,6 +215,8 @@ class TestExpressions:
         #
         assert evalpy('{1:2} or 42') == "{ '1': 2 }"
         assert evalpy('{} or 42') == '42'
+        assert evalpy('{} or 0') == '0'
+        assert evalpy('None or []') == '[]'
         
         # Eval extra types
         assert evalpy('null or 42') == '42'


### PR DESCRIPTION
`foo = xx or []`  would yield `False` instead of `[]`, because of how the `truthy` function works. This PR makes the last entry in an OR be passed as is, and makes `truthy` wrap when an expression contains an or.