### PR TITLE
Fix locating firefox on OS X

### DIFF
--- a/flexx/webruntime/xul.py
+++ b/flexx/webruntime/xul.py
@@ -170,7 +170,19 @@ def get_firefox_exe():
         paths.append('/usr/lib/iceweasel/iceweasel')
         paths.append('/usr/lib64/iceweasel/iceweasel')
     elif sys.platform.startswith('darwin'):
-        paths.append('/Applications/Firefox.app/Contents/MacOS/firefox')
+        try:
+            # Use app-id to get the .app path
+            osx_search_arg='kMDItemCFBundleIdentifier==org.mozilla.firefox'
+            basepath = subprocess.check_output(['mdfind', osx_search_arg]).rstrip()
+            if basepath:
+                paths.append(op.join(basepath,'Contents/MacOS/firefox'))
+        except (OSError, subprocess.CalledProcessError):
+            pass
+        # '~/Applications' and '/Applications'
+        osx_user_apps = op.join(os.environ['HOME'], 'Applications')
+        osx_root_apps = '/Applications'
+        paths.append(op.join(osx_user_apps, 'Firefox.app/Contents/MacOS/firefox'))
+        paths.append(op.join(osx_root_apps, 'Firefox.app/Contents/MacOS/firefox'))
 
     # Try location until we find one that exists
     for path in paths:


### PR DESCRIPTION
Some mac installations don't link firefox into '/Applications', (e.g. homebrew links into '~/Applications'). A more reliable method is to use the app id for getting the path, (i.e. 'mdfind kMDItemCFBundleIdentifier==org.mozilla.firefox').
For path fallbacks, '~/Applications/...' added in addition to '/Applications/...'.