### PR TITLE
Revisions to the event system

### DIFF
--- a/flexx/app/examples/find_prime.py
+++ b/flexx/app/examples/find_prime.py
@@ -8,45 +8,38 @@ performance.
 from flexx import app
 
 
-def _find_prime(self, n):
-    """ The code that is executed on both Python and JS (via PyScript)
-    """
-    primes = []
-    
-    def isprime(x):
-        if x <= 1:
-            return False
-        elif x == 2:
-            return True
-        for i in range(2, x//2+1):
-            if x % i == 0:
-                return False
-        return True
-    
-    import time  # import here, so PyScript picks is up
-    t0 = time.perf_counter()
-    i = 0
-    while len(primes) < n:
-        i += 1
-        if isprime(i):
-            primes.append(i)
-    t1 = time.perf_counter()
-    print(i, 'found in ', t1-t0, 'seconds')
-
-
 class PrimeFinder(app.Model):
-    
-    _find_prime = _find_prime
     
     def find_prime_py(self, n):
         self._find_prime(n)
     
-    class JS:
-        _find_prime = _find_prime
-        
     def find_prime_js(self, n):
         self.call_js('_find_prime(%i)' % n)
-
+    
+    class Both:
+        
+        def _find_prime(self, n):
+            primes = []
+            
+            def isprime(x):
+                if x <= 1:
+                    return False
+                elif x == 2:
+                    return True
+                for i in range(2, x//2+1):
+                    if x % i == 0:
+                        return False
+                return True
+            
+            import time  # import here, so PyScript picks is up
+            t0 = time.perf_counter()
+            i = 0
+            while len(primes) < n:
+                i += 1
+                if isprime(i):
+                    primes.append(i)
+            t1 = time.perf_counter()
+            print(i, 'found in ', t1-t0, 'seconds')
 
 if __name__ == '__main__':
     

--- a/flexx/app/examples/parent_children.py
+++ b/flexx/app/examples/parent_children.py
@@ -3,57 +3,65 @@ This example demonstrates a parent-children relationship for nodes,
 that gets synced between Python and JS. This is basically a
 stripped-down version of what is used in the Widget class.
 
-The idea is to implement the "parent" and "children" properties using
-the "both" flag, so that the same implementation is used in Python and
-JavaScript. Then we disable syncing of parent, so that the syncing
-happens via the children property only, otherwiser we end up with
-infinite loops.
+The idea is to make the "parent" and "children" properties available
+in both Python and JS. However, if they were both synced, we would get
+an infinite loop. Therefore the parent property is added as a "local"
+property to both Py and JS, using a common validator function.
 """
 
 from flexx import event, app
 
 
+def parent(self, new_parent=None):
+    old_parent = self.parent
+    
+    if old_parent is not None:
+        children = list(old_parent.children if old_parent.children else [])
+        while self in children:
+            children.remove(self)
+        old_parent.children = children
+    if new_parent is not None:
+        children = list(new_parent.children if new_parent.children else [])
+        children.append(self)
+        new_parent.children = children
+    
+    return new_parent
+
+
 class Node(app.Model):
     
-    @event.prop(both=True, sync=False)
-    def parent(self, new_parent=None):
-        old_parent = self.parent
-        
-        if old_parent is not None:
-            children = list(old_parent.children if old_parent.children else [])
-            while self in children:
-                children.remove(self)
-            old_parent.children = children
-        if new_parent is not None:
-            children = list(new_parent.children if new_parent.children else [])
-            children.append(self)
-            new_parent.children = children
-        
-        return new_parent
+    parent = event.prop(parent)
     
-    @event.prop(both=True)
-    def children(self, new_children=()):
-        old_children = self.children
-        if not old_children:  # Can be None during initialization
-            old_children = []
-        
-        for child in old_children:
-            if child not in new_children:
-                child.parent = None
-        for child in new_children:
-            if child not in old_children:
-                child.parent = self
-        
-        return tuple(new_children)
-    
+    @event.connect('parent')
     def on_parent(self, *events):
         parent = events[-1].new_value
         parent_id = 'None' if parent is None else parent._id
         print('parent of %s changed to %s in Py' % (self._id, parent_id))
     
+    class Both:
+        
+        # cannot define parent prop here; it would result in an infinite loop
+        
+        @event.prop
+        def children(self, new_children=()):
+            old_children = self.children
+            if not old_children:  # Can be None during initialization
+                old_children = []
+            
+            for child in old_children:
+                if child not in new_children:
+                    child.parent = None
+            for child in new_children:
+                if child not in old_children:
+                    child.parent = self
+            
+            return tuple(new_children)
     
     class JS:
         
+        parent = event.prop(parent)
+        
+        @event.connect('parent')
         def on_parent(self, *events):
             parent = events[-1].new_value
             parent_id = 'None' if parent is None else parent._id

--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -503,7 +503,7 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
     
     def emit(self, type, ev, fromjs=False):
         ev = super().emit(type, ev)
-        isprop = type in self.__properties__  # are emitted via their proxies
+        isprop = type in self.__properties__ and type not in self.__local_properties__
         if not fromjs and not isprop and type in self.__event_types_js:
             cmd = 'flexx.instances.%s._emit_from_py(%s, %r);' % (
                 self._id, serializer.saves(type), serializer.saves(ev))
@@ -584,7 +584,8 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
         
         def emit(self, type, ev, frompy=False):
             ev = super().emit(type, ev)
-            isprop = self.__properties__.indexOf(type) >= 0
+            isprop = (self.__properties__.indexOf(type) >= 0 and
+                      self.__local_properties__.indexOf(type) < 0)
             
             if not frompy and not isprop and type in self.__event_types_py:
                 txt = window.flexx.serializer.saves(ev)

--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -72,7 +72,7 @@ import threading
 from .. import event
 from ..event._hasevents import (with_metaclass, new_type, HasEventsMeta,
                                 finalize_hasevents_class)
-from ..event._emitters import Property, Emitter
+from ..event._emitters import Emitter
 from ..event._js import create_js_hasevents_class, HasEventsJS
 from ..pyscript import py2js, js_rename, window, Parser
 
@@ -556,7 +556,8 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
             # Note: there is quite a bit of _pyfunc_truthy in the ifs here
             if window.flexx.ws is None:
                 super()._set_prop(name, value, _initial)
-                # todo: except NotImplemented? window.console.warn("Cannot set prop '%s' because its validated "
+                # todo: allow raising NotImplemented to avoid validationin either JS or Py?
+                # window.console.warn("Cannot set prop '%s' because its validated "
                 #                        "in Py, but there is no websocket." % name)
                 return
             

--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -550,15 +550,13 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
         
         def _set_prop(self, name, value, _initial=False, frompy=False):
             
+            # Note: there is quite a bit of _pyfunc_truthy in the ifs here
+            
             islocal = self.__local_properties__.indexOf(name) >= 0
             issyncable = not _initial and not islocal
             
-            # Note: there is quite a bit of _pyfunc_truthy in the ifs here
-            if window.flexx.ws is None:
+            if window.flexx.ws is None:  # Exported app
                 super()._set_prop(name, value, _initial)
-                # todo: allow raising NotImplemented to avoid validationin either JS or Py?
-                # window.console.warn("Cannot set prop '%s' because its validated "
-                #                        "in Py, but there is no websocket." % name)
                 return
             
             ischanged = super()._set_prop(name, value, _initial)

--- a/flexx/app/tests/test_live.py
+++ b/flexx/app/tests/test_live.py
@@ -153,7 +153,7 @@ class ModelC(ModelB):
     def test_check(self):
         py_result = ' '.join(self.__properties__) + ' - ' + ' '.join(self.__local_properties__)
         js_result = self.result
-        assert py_result == 'foo1 foo2 foo3 result spam1 spam2 spam3 - spam1 spam2 spam3'
+        assert py_result == 'foo1 foo2 foo3 result spam1 spam2 spam3 sync_props - spam1 spam2 spam3 sync_props'
         assert js_result == 'bar1 bar2 bar3 foo1 foo2 foo3 result - bar1 bar2 bar3'
         print('C ok')
     

--- a/flexx/app/tests/test_live.py
+++ b/flexx/app/tests/test_live.py
@@ -6,6 +6,7 @@ import time
 import sys
 
 from flexx import app, event, webruntime
+from flexx.pyscript import this_is_js
 
 from flexx.util.testing import run_tests_if_main, raises, skip
 
@@ -13,42 +14,38 @@ from flexx.util.testing import run_tests_if_main, raises, skip
 ON_TRAVIS = os.getenv('TRAVIS', '') == 'true'
 ON_PYPY = '__pypy__' in sys.builtin_module_names
 
-TIMEOUT1 = 10.0 if ON_TRAVIS else 3.0
+TIMEOUT1 = 10.0  # Failsafe
 TIMEOUT2 = 1.0
 
 
 def runner(cls):
-    t = app.launch(cls, 'firefox')  # fails somehow with XUL
+    t = app.launch(cls, 'xul')  # fails somehow with XUL
     t.test_init()
-    app.call_later(TIMEOUT1, app.stop)
-    app.run()
+    # Install failsafe. Use a closure so failsafe wont spoil a future test
+    isrunning = True
+    def stop():
+        if isrunning:
+            app.stop()
+    app.call_later(TIMEOUT1, stop)
+    # Enter main loop until we get out
+    t0 = time.time()
+    app.start()
+    print('ran %f seconds' % (time.time()-t0))
+    isrunning = False
+    # Check result
     if not (ON_TRAVIS and ON_PYPY):  # has intermittent fails on pypy3
         t.test_check()
+    # Shut down
     t.session.close()
 
 
 class ModelA(app.Model):
-    
-    @event.prop
-    def foo1(self, v=0):
-        return float(v+1)
-    
-    @event.prop
-    def foo2(self, v=0):
-        return float(v+1)
-
-    @event.prop
-    def result(self, v=None):
-        if v:
-            #app.stop()
-            print('stopping by ourselves', v)
-            app.call_later(TIMEOUT2, app.stop)
-        return v
+    """ Test both props, py-only props and js-only props.
+    """
     
     def test_init(self):
         
         assert self.foo1 == 1
-        assert self.bar1 is None  # not yet initialized
         
         self.call_js('set_result()')
     
@@ -56,12 +53,37 @@ class ModelA(app.Model):
         assert self.foo1 == 1
         assert self.foo2 == 1
         #
-        assert self.bar1 == 1
-        assert self.bar2 == 1
-        #
+        assert self.spam1 == 1
+        assert self.spam2 == 1
         assert self.result == '1 1 - 1 1'
         print('A ok')
     
+    @event.prop
+    def spam1(self, v=0):
+        return int(v+1)
+    
+    @event.prop
+    def spam2(self, v=0):
+        return int(v+1)
+    
+    class Both:
+        
+        @event.prop
+        def result(self, v=None):
+            if v and not this_is_js():
+                #app.stop()
+                print('stopping by ourselves', v)
+                app.call_later(TIMEOUT2, app.stop)
+            return v
+        
+        @event.prop
+        def foo1(self, v=0):
+            return float(v+1)
+        
+        @event.prop
+        def foo2(self, v=0):
+            return float(v+1)
+        
     class JS:
         
         @event.prop
@@ -77,26 +99,37 @@ class ModelA(app.Model):
                                     self.bar1, self.bar2])
 
 class ModelB(ModelA):
-    
-    @event.prop
-    def foo2(self, v=0):
-        return int(v+2)
-    
-    @event.prop
-    def foo3(self, v=0):
-        return int(v+2)
+    """ Like A, but some inheritance in the mix.
+    """
     
     def test_check(self):
         assert self.foo1 == 1
         assert self.foo2 == 2
         assert self.foo3 == 2
         #
-        assert self.bar1 == 1
-        assert self.bar2 == 2
-        assert self.bar3 == 2
-        #
+        assert self.spam1 == 1
+        assert self.spam2 == 2
+        assert self.spam3 == 2
         assert self.result == '1 2 2 - 1 2 2'
         print('B ok')
+    
+    @event.prop
+    def spam2(self, v=0):
+        return int(v+2)
+    
+    @event.prop
+    def spam3(self, v=0):
+        return int(v+2)
+    
+    class Both:
+        
+        @event.prop
+        def foo2(self, v=0):
+            return int(v+2)
+        
+        @event.prop
+        def foo3(self, v=0):
+            return int(v+2)
     
     class JS:
         
@@ -114,33 +147,32 @@ class ModelB(ModelA):
 
 
 class ModelC(ModelB):
-    # Test properties and proxy properties, no duplicates etc.
+    """ Test properties and local properties, no duplicates etc.
+    """
     
     def test_check(self):
-        py_result = ' '.join(self.__properties__) + ' - ' + ' '.join(self.__proxy_properties__)
+        py_result = ' '.join(self.__properties__) + ' - ' + ' '.join(self.__local_properties__)
         js_result = self.result
-        assert py_result == 'bar1 bar2 bar3 foo1 foo2 foo3 result - bar1 bar2 bar3'
-        assert js_result == 'bar1 bar2 bar3 foo1 foo2 foo3 result - foo1 foo2 foo3 result'
+        assert py_result == 'foo1 foo2 foo3 result spam1 spam2 spam3 - spam1 spam2 spam3'
+        assert js_result == 'bar1 bar2 bar3 foo1 foo2 foo3 result - bar1 bar2 bar3'
         print('C ok')
     
     class JS:
         
         def set_result(self):
-            self.result = ' '.join(self.__properties__) + ' - ' + ' '.join(self.__proxy_properties__)
+            self.result = ' '.join(self.__properties__) + ' - ' + ' '.join(self.__local_properties__)
 
 
 class ModelD(ModelB):
-    # Test setting properties
+    """ Test setting properties
+    """
     
     def test_init(self):
         
         assert self.foo2 == 2
         self.foo2 = 10
+        self.spam2 = 10
         assert self.foo2 == 12
-        
-        assert self.bar2 is None
-        self.bar2 = 10
-        assert self.bar2 is None 
         
         self.call_js('set_result()')
     
@@ -148,10 +180,9 @@ class ModelD(ModelB):
         
         assert self.result == 'ok'
         
-        assert self.foo2 == 12
-        assert self.foo3 == 12
-        assert self.bar2 == 12
-        assert self.bar3 == 12
+        assert self.foo2 == 16  # +2 in py - js - py
+        assert self.foo3 == 14  # +2 in js - py
+        assert self.spam2 == 12
     
     class JS:
         
@@ -161,21 +192,22 @@ class ModelD(ModelB):
             
             assert self.foo3 == 2
             self.foo3 = 10
-            assert self.foo3 == 2
+            assert self.foo3 == 12
             
             assert self.bar3 == 2
             self.bar3 = 10
             assert self.bar3 == 12
         
         def set_result(self):
-            assert self.foo2 == 12
-            # assert self.foo3 == 12  # this takes more cycles, hard to test
-            assert self.bar2 == 12
+            assert self.foo2 == 14  # +2 +2
+            assert self.foo3 == 12
             assert self.bar3 == 12
             self.result = 'ok'
 
 
 class ModelE(ModelA):
+    """ Test counting events
+    """
     
     def init(self):
         self.res1 = []
@@ -225,14 +257,17 @@ class ModelE(ModelA):
         def foo_handler(self, *events):
             self.res3.append(len(events))
             print('JS saw %i foo events' % len(events))
+            self._maybe_set_result()
         
         @event.connect('bar')
         def bar_handler(self, *events):
             self.res4.append(len(events))
             print('JS saw %i bar events' % len(events))
+            self._maybe_set_result()
         
-        def set_result(self):
-            self.result = self.res3 + [''] + self.res4
+        def _maybe_set_result(self):
+            if self.res3 and self.res4:
+                self.result = self.res3 + [''] + self.res4
 
 
 ##
@@ -251,10 +286,10 @@ def test_generated_javascript():
     assert codeA.count('_bar3_func = function') == 0
     
     assert codeB.count('_foo1_func = function') == 0
-    assert codeB.count('_foo2_func = function') == 0  # proxy needs no new func
+    assert codeB.count('_foo2_func = function') == 1
     assert codeB.count('_foo3_func = function') == 1
     assert codeB.count('_bar1_func = function') == 0
-    assert codeB.count('_bar2_func = function') == 1  # but real prop does
+    assert codeB.count('_bar2_func = function') == 1
     assert codeB.count('_bar3_func = function') == 1
 
 
@@ -272,5 +307,5 @@ def test_apps():
 
 # NOTE: beware future self: if running this in Pyzo, turn off GUI integration!
 
-# runner(ModelE)
+#runner(ModelB)
 run_tests_if_main()

--- a/flexx/app/tests/test_live.py
+++ b/flexx/app/tests/test_live.py
@@ -270,6 +270,56 @@ class ModelE(ModelA):
                 self.result = self.res3 + [''] + self.res4
 
 
+
+class ModelF(ModelA):
+    """ Test that props emit events (even for local props).
+    """
+    
+    def test_init(self):
+        
+        self.res = []
+        
+        self.foo1 = 2
+        self.spam1 = 2
+        
+        self.call_js('set_result()')
+    
+    def test_check(self):
+        assert self.res.count('foo1') == 3  # bit of a glitch bc we do +1
+        assert self.res.count('foo2') == 2
+        assert self.res.count('bar1') == 2
+        assert self.res.count('spam1') == 2
+        
+        assert self.result.count('foo1') == 2
+        assert self.result.count('foo2') == 2
+        assert self.result.count('bar1') == 2
+        assert self.result.count('spam1') == 2
+        
+        print('F ok')
+    
+    @event.connect('foo1', 'foo2', 'spam1', 'bar1')
+    def on_prop_change(self, *events):
+        for ev in events:
+            self.res.append(ev.type)
+    
+    class JS:
+        
+        def init(self):
+            super().init()
+            self.res = []
+        
+        @event.connect('foo1', 'foo2', 'spam1', 'bar1')
+        def on_prop_change(self, *events):
+            for ev in events:
+                self.res.append(ev.type)
+        
+        def set_result(self):
+            self.foo2 = 10
+            self.bar1 = 10
+            self.on_prop_change.handle_now()
+            
+            self.result = self.res
+
 ##
 
 
@@ -307,5 +357,5 @@ def test_apps():
 
 # NOTE: beware future self: if running this in Pyzo, turn off GUI integration!
 
-#runner(ModelB)
+#runner(ModelF)
 run_tests_if_main()

--- a/flexx/app/tests/test_model.py
+++ b/flexx/app/tests/test_model.py
@@ -57,13 +57,39 @@ class Foo4(Foo3):
         def red(self, v=0):
             return v+1
 
+class Foo5(Foo4):
+    
+    class Both:
+        
+        @event.prop
+        def red(self, v=0):
+            return v+1
+        
+        @event.prop
+        def blue(self, v=0):
+            return v+1
+        
+        @event.prop
+        def purple(self, v=0):
+            return v+1
+
+
+class Foo6(Foo1):
+    
+    class JS:
+        
+        @event.emitter
+        def my_awesome_event(self, x):
+            """ docs on awesome event. """
+            return {}
+
 
 def test_pairing1():
     
     assert isinstance(Foo1.title, event._emitters.Property)
-    assert isinstance(Foo1.blue, event._emitters.Property)
+    assert not hasattr(Foo1, 'blue')
     
-    assert isinstance(Foo1.JS.title, event._emitters.Property)
+    assert not hasattr(Foo1.JS, 'title')
     assert isinstance(Foo1.JS.blue, event._emitters.Property)
 
 
@@ -93,6 +119,55 @@ def test_overloading():
     assert Foo4.JS.red is not Foo2.JS.red
 
 
+def test_both():
+    # New prop
+    assert Foo5.purple is Foo5.JS.purple
+    # Overloaded existing props
+    assert Foo5.red is Foo5.JS.red
+    assert Foo5.blue is Foo5.JS.blue
+    
+    # But this fails
+    
+    with raises(TypeError):
+        
+        class Foo5_wrong1(Foo4):
+            
+            @event.prop
+            def purple(self, v=0):
+                return v+1
+            
+            class Both:
+                
+                @event.prop
+                def purple(self, v=0):
+                    return v+1
+    
+    with raises(TypeError):
+        
+        class Foo5_wrong2(Foo4):
+            
+            class JS:
+                @event.prop
+                def purple(self, v=0):
+                    return v+1
+            
+            class Both:
+                
+                @event.prop
+                def purple(self, v=0):
+                    return v+1
+
+
+def test_emitters_in_JS():
+    # Emitters in JS get a dummy emitter in Py
+    assert Foo6.my_awesome_event
+    assert 'docs on awesome' in Foo6.my_awesome_event.__doc__
+    
+
+    with raises(RuntimeError):
+        Foo6.my_awesome_event._func(None)
+
+
 def test_no_duplicate_code():
     assert '_blue_func' in Foo1.JS.CODE
     assert '_blue_func' not in Foo2.JS.CODE
@@ -101,6 +176,16 @@ def test_no_duplicate_code():
     assert '_red_func' not in Foo1.JS.CODE
     assert '_red_func' in Foo2.JS.CODE
     assert '_red_func' in Foo4.JS.CODE
+
+
+def test_get_instance_by_id():
+    m1 = Foo1()
+    m2 = Foo1()
+    
+    assert m1 is not m2
+    assert app.get_instance_by_id(m1.id) is m1
+    assert app.get_instance_by_id(m2.id) is m2
+    assert app.get_instance_by_id('blaaaa') is None
 
 
 def test_active_models():

--- a/flexx/app/tests/test_model.py
+++ b/flexx/app/tests/test_model.py
@@ -179,6 +179,12 @@ def test_no_duplicate_code():
 
 
 def test_get_instance_by_id():
+    
+    # This test needs a default session
+    session = app.manager.get_default_session()
+    if session is None:
+        app.manager.create_default_session()
+    
     m1 = Foo1()
     m2 = Foo1()
     

--- a/flexx/event/__init__.py
+++ b/flexx/event/__init__.py
@@ -254,9 +254,10 @@ is a ``HasEvents`` subclass that has properties ``parent`` and
         ...
 
 The ``parent_foo_handler`` gets invoked when the "foo" event gets
-emitted on the parent of main, *and* when the parent of main changes.
-Similarly, the ``children_foo_handler`` gets invoked when any of the
-children emits its "foo" event, or when the children property changes.
+emitted on the parent of main. Similarly, the ``children_foo_handler``
+gets invoked when any of the children emits its "foo" event. Note that
+in some cases you might also want to connect to changes of the ``parent``
+or ``children`` property itself.
 
 The event system automatically reconnects handlers when necessary. This
 concept makes it very easy to connect to the right events without the

--- a/flexx/event/__init__.py
+++ b/flexx/event/__init__.py
@@ -76,14 +76,14 @@ One can also see that the handler function accepts ``*events`` argument.
 This is because handlers can be passed zero or more events. If a handler
 is called manually (e.g. ``ob.handle_foo()``) it will have zero events.
 When called by the event system, it will have at least 1 event. When
-multiple events are emitted in a row, the handler function is called
+e.g. a property is set twice, the handler function is called
 just once, with multiple events, in the next event loop iteration. It
 is up to the programmer to determine whether only one action is
 required, or whether all events need processing. In the latter case,
 just use ``for ev in events: ``.
 
-Another feature of this system is that a handler can connect to multiple
-events:
+Another useful feature of this system is that a handler can connect to
+multiple events at once:
 
 .. code-block:: python
 
@@ -111,17 +111,6 @@ To create a handler from a normal function, use the
     h.connect(handle_func2, 'foo', 'bar')
 
 
-Handlers can be implicitly created by prefixing a method with ``on_``:
-
-.. code-block:: python
-
-    class MyObject(event.HasEvents):
-       
-        def on_foo(self, *events):
-            # This gets connected to the "foo" event
-            print(events)
-
-
 Event emitters
 --------------
 
@@ -144,12 +133,12 @@ Settable properties can be created easiliy using the
             '''
             return float(v)
 
-The function that is decorated should have one argument (the new value
-for the property), which can have a default value (representing the
-initial value). The function body is used to validate
-and normalize the provided input. In this case the input is simply cast
-to a float. The docstring of the function will be the docstring of the
-property (e.g. for Sphynx docs).
+The function that is decorated is essentially the setter function, and
+should have one argument (the new value for the property), which can
+have a default value (representing the initial value). The function
+body is used to validate and normalize the provided input. In this case
+the input is simply cast to a float. The docstring of the function will
+be the docstring of the property (e.g. for Sphynx docs).
 
 An alternative initial value for a property can be provided upon instantiation:
 
@@ -267,7 +256,7 @@ is a ``HasEvents`` subclass that has properties ``parent`` and
 The ``parent_foo_handler`` gets invoked when the "foo" event gets
 emitted on the parent of main, *and* when the parent of main changes.
 Similarly, the ``children_foo_handler`` gets invoked when any of the
-children emits its "foo" signal, or when the children property changes.
+children emits its "foo" event, or when the children property changes.
 
 The event system automatically reconnects handlers when necessary. This
 concept makes it very easy to connect to the right events without the
@@ -318,9 +307,8 @@ Overloadable event handlers
 
 In Qt, the "event system" consists of methods that handles an event, which
 can be overloaded in subclasses to handle an event differently. In
-``flexx.event``, a handler can be implemented simply by naming a method
-``on_xx``. Doing so allows subclasses to re-implement the handler, and
-optionally call the original handler using ``super()``.
+``flexx.event``, handlers can similarly be re-implemented in subclasses,
+and these can call the original handler using ``super()`` if needed.
 
 Publish-subscribe pattern
 ==========================

--- a/flexx/event/_emitters.py
+++ b/flexx/event/_emitters.py
@@ -8,7 +8,7 @@ import inspect
 
 # Decorators to apply at a HasEvents class
 
-def prop(func=None, **flags):
+def prop(func):
     """ Decorator to define a settable propery. An event is emitted
     when the property is set, which has values for "old_value" and
     "new_value".
@@ -25,20 +25,18 @@ def prop(func=None, **flags):
         m = MyObject(foo=2)
         m.foo = 3
     
-    The method should have one argument, which should have a default
-    value, which represents the initial value of the property. The body
+    The method should have one argument, which can have a default
+    value to specify the initial value of the property. The body
     of the method is used to do verification and normalization of the
     value being set. The method's docstring is used as the property's
     docstring.
     """
-    def _prop(func):
-        if not callable(func):
-            raise TypeError('prop decorator needs a callable')
-        return Property(func, flags=flags)
-    return _prop if func is None else _prop(func)
+    if not callable(func):
+        raise TypeError('prop decorator needs a callable')
+    return Property(func)
 
 
-def readonly(func=None, **flags):
+def readonly(func):
     """ Decorator to define a readonly property. An event is emitted
     when the property is set, which has values for "old_value" and
     "new_value". To set a readonly property internally, use the
@@ -56,14 +54,12 @@ def readonly(func=None, **flags):
         m._set_prop('bar', 2)  # only for internal use
     
     """
-    def _readonly(func):
-        if not callable(func):
-            raise TypeError('readonly decorator needs a callable')
-        return Readonly(func, flags=flags)
-    return _readonly if func is None else _readonly(func)
+    if not callable(func):
+        raise TypeError('readonly decorator needs a callable')
+    return Readonly(func)
 
 
-def emitter(func=None, **flags):
+def emitter(func):
     """ Decorator to define an emitter. An emitter is an attribute that
     makes it easy to emit specific events and functions as a placeholder
     for documenting an event.
@@ -83,22 +79,19 @@ def emitter(func=None, **flags):
     dictionary that represents the event to generate. The method's
     docstring is used as the emitter's docstring.
     """
-    def _emitter(func):
-        if not callable(func):
-            raise TypeError('emitter decorator needs a callable')
-        return Emitter(func, flags=flags)
-    return _emitter if func is None else _emitter(func)
+    if not callable(func):
+        raise TypeError('emitter decorator needs a callable')
+    return Emitter(func)
 
 
 class BaseEmitter:
     """ Base class for descriptors used for generating events.
     """
     
-    def __init__(self, func, name=None, doc=None, flags=None):
+    def __init__(self, func, name=None, doc=None):
         assert callable(func)
         self._func = func
         self._name = name or func.__name__  # updated by HasEvents meta class
-        self._flags = flags or {}
         self.__doc__ = '*%s*: %s' % (self.__class__.__name__.lower(),
                                      doc or func.__doc__ or self._name)
     

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -27,9 +27,9 @@ def connect(*connection_strings):
     dynamism and labels for further information on the possibilities
     of connection strings.
     
-    Note that naming a method ``on_foo()`` will be automatically
-    connected to event "foo". To connect a regular function to an event,
-    use the :func:`HasEvents.connect() <flexx.event.HasEvents.connect>` method.
+    To connect functions or methods to an event from another HasEvents
+    object, use that object's
+    :func:`HasEvents.connect()<flexx.event.HasEvents.connect>` method.
     
     .. code-block:: py
         

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -233,10 +233,11 @@ class Handler:
         events = []
         reconnect = []
         for label, ev in self._pending:
-            events.append(ev)
             if label.startswith('reconnect_'):
                 index = int(label.split('_')[-1])
                 reconnect.append(index)
+            else:
+                events.append(ev)
         self._pending = []
         # Reconnect (dynamism)
         for index in reconnect:

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -238,22 +238,24 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
                 handlers.pop(i)
         self._handlers_changed_hook()
     
-    def emit(self, type, ev):
+    def emit(self, type, info=None):
         """ Generate a new event and dispatch to all event handlers.
         
         Arguments:
             type (str): the type of the event. Should not include a label.
-            ev (dict): the event object. This dict is turned into a Dict,
-                so that its elements can be accesses as attributes.
+            info (dict): Optional. Additional information to attach to
+                the event object. Note that the actual event is a Dict object
+                that allows its elements to be accesses as attributes.
         """
+        info = {} if info is None else info
         type, _, label = type.partition(':')
         if len(label):
             raise ValueError('The type given to emit() should not include a label.')
         # Prepare event
-        if not isinstance(ev, dict):
-            raise TypeError('Event object (for %r) must be a dict, not %r' %
-                            (type, ev))
-        ev = Dict(ev)  # make copy and turn into nicer Dict on py
+        if not isinstance(info, dict):
+            raise TypeError('Info object (for %r) must be a dict, not %r' %
+                            (type, info))
+        ev = Dict(info)  # make copy and turn into nicer Dict on py
         ev.type = type
         ev.source = self
         # Push the event to the handlers (handlers use labels for dynamism)

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -38,7 +38,7 @@ def new_type(name, *args, **kwargs):
 class HasEventsMeta(type):
     """ Meta class for HasEvents
     * Set the name of each handler and emitter.
-    * Sets __handlers__, __emitters, __signals__ attribute on the class.
+    * Sets __handlers__, __emitters, __properties__ attribute on the class.
     """
     
     def __init__(cls, name, bases, dct):
@@ -69,10 +69,6 @@ def finalize_hasevents_class(cls):
         elif isinstance(val, Handler):
             raise RuntimeError('Class methods can only be made handlers using '
                                '@event.connect() (handler %r)' % name)
-        elif name.startswith('on_'):
-            val = HandlerDescriptor(val, [name[3:]])
-            setattr(cls, name, val)
-            handlers[name] = val
     # Finalize all found emitters
     for collection in (handlers, emitters, properties):
         for name, descriptor in collection.items():
@@ -119,12 +115,14 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             
             # Handlers
             
-            @event.connect
+            @event.connect('foo')
             def handle_foo(self, *events):
                 print('foo was set to', events[-1].new_value)
             
+            @event.connect('bar')
             def on_bar(self, *events):
-                print('bar event was generated')
+                for ev in events:
+                    print('bar event was generated')
         
         ob = MyObject(foo=42)
         

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -78,12 +78,6 @@ def finalize_hasevents_class(cls):
         for name, descriptor in collection.items():
             descriptor._name = name
             setattr(cls, '_' + name + '_func', descriptor._func)
-    # Apply flags
-    flags = {}
-    for collection in (emitters, properties):
-        for name, descriptor in collection.items():
-            flags[name] = descriptor._flags
-    cls.__emitter_flags__ = flags
     # Cache prop names
     cls.__handlers__ = [name for name in sorted(handlers.keys())]
     cls.__emitters__ = [name for name in sorted(emitters.keys())]

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -48,8 +48,7 @@ class HasEventsMeta(type):
 def finalize_hasevents_class(cls):
     """ Given a class, analyse its Properties, Readonlies, Emitters,
     and Handlers, to set a list of __emitters__, __properties__, and
-    __handlers__. Also convert methods named on_foo to a handler of the
-    'foo' event, and create private methods corresponding to the
+    __handlers__. Also create private methods corresponding to the
     properties, emitters and handlers.
     """
     # Collect handlers defined on this class

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -69,6 +69,11 @@ def finalize_hasevents_class(cls):
         elif isinstance(val, Handler):
             raise RuntimeError('Class methods can only be made handlers using '
                                '@event.connect() (handler %r)' % name)
+        elif callable(val) and name.startswith('on_'):
+            # todo: remove this between 0.3 and 0.4
+            logger.warn('Method %r starting with "on_" is not (anymore) '
+                        'converted to a handler.' % name)
+    
     # Finalize all found emitters
     for collection in (handlers, emitters, properties):
         for name, descriptor in collection.items():

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -374,6 +374,9 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             
             # Direct usage
             h.connect(greet, 'first_name', 'last_name')
+            
+            # Order does not matter
+            h.connect('first_name', greet)
         
         """
         return self.__connect(*connection_strings)  # calls Py or JS version
@@ -387,6 +390,9 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         if callable(connection_strings[0]):
             func = connection_strings[0]
             connection_strings = connection_strings[1:]
+        elif callable(connection_strings[-1]):
+            func = connection_strings[-1]
+            connection_strings = connection_strings[:-1]
         
         for s in connection_strings:
             if not (isinstance(s, str) and len(s) > 0):

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -198,7 +198,7 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
     special_funcs = ['_%s_func' % name for name in 
                      (cls.__handlers__ + cls.__emitters__ + cls.__properties__)]
     OK_MAGICS = ('__properties__', '__emitters__', '__handlers__',
-                 '__proxy_properties__', '__emitter_flags__')
+                 '__local_properties__', '__emitter_flags__')
     
     for name, val in sorted(cls.__dict__.items()):
         name = name.replace('_JS__', '_%s__' % cls_name.split('.')[-1])  # fix mangling

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -67,9 +67,8 @@ class HasEventsJS:
     
     def __init_handlers(self, initial_pending_events):
         # Create handlers
-        # Note that methods on_xxx are converted by the HasEvents meta class
         for name in self.__handlers__:
-            func = self['_' + name + '_func']
+            func = self[name]
             self[name] = self.__create_Handler(func, name, func._connection_strings)
         # Emit events for properties
         for ev in initial_pending_events:
@@ -203,10 +202,10 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
     
     for name, val in sorted(cls.__dict__.items()):
         name = name.replace('_JS__', '_%s__' % cls_name.split('.')[-1])  # fix mangling
-        funcname = '_' + name + '_func'
         if name in special_funcs:
             pass
         elif isinstance(val, BaseEmitter):
+            funcname = '_' + name + '_func'
             if isinstance(val, Property):
                 properties.append(name)
             else:
@@ -229,6 +228,7 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
             funcs_code.append(t % (cls_name, funcname, reprs(emitter_type)))
             funcs_code.append('')
         elif isinstance(val, HandlerDescriptor):
+            funcname = name  # funcname is simply name, so that super() works
             handlers.append(name)
             # Add function def
             code = py2js(val._func, cls_name + '.prototype.' + funcname)

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -198,7 +198,7 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
     special_funcs = ['_%s_func' % name for name in 
                      (cls.__handlers__ + cls.__emitters__ + cls.__properties__)]
     OK_MAGICS = ('__properties__', '__emitters__', '__handlers__',
-                 '__local_properties__', '__emitter_flags__')
+                 '__local_properties__')
     
     for name, val in sorted(cls.__dict__.items()):
         name = name.replace('_JS__', '_%s__' % cls_name.split('.')[-1])  # fix mangling

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -74,18 +74,28 @@ class HasEventsJS:
         for ev in initial_pending_events:
             self._emit(ev)
     
-    def __connect(self, func, *connection_strings):
+    def __connect(self, *connection_strings):
         # The JS version (no decorator functionality)
         
-        if len(connection_strings) == 0:
-            raise RuntimeError('connect() (js) needs one or more connection strings.')
+        if len(connection_strings) < 2:
+            raise RuntimeError('connect() (js) needs a function and one or ' +
+                               'more connection strings.')
         
+        # Get callable
+        if callable(connection_strings[0]):
+            func = connection_strings[0]
+            connection_strings = connection_strings[1:]
+        elif callable(connection_strings[-1]):
+            func = connection_strings[-1]
+            connection_strings = connection_strings[:-1]
+        else:
+            raise TypeError('connect() decorator requires a callable.')
+        
+        # Verify connection strings
         for s in connection_strings:
             if not (isinstance(s, str) and len(s)):
                 raise ValueError('Connection string must be nonempty strings.')
         
-        if not callable(func):
-            raise TypeError('connect() decotator requires a callable.')
         return self.__create_Handler(func, func.name or 'anonymous', connection_strings)
     
     def __create_PyProperty(self, name):

--- a/flexx/event/examples/basic_emit.py
+++ b/flexx/event/examples/basic_emit.py
@@ -8,9 +8,11 @@ from flexx import event
 
 class Basic(event.HasEvents):
     
+    @event.connect('foo')
     def on_foo(self, *events):
         print('foo handler called with %i events' % len(events))
     
+    @event.connect('bar')
     def on_bar(self, *events):
         print('bar handler called with %i events' % len(events))
 

--- a/flexx/event/tests/test_both.py
+++ b/flexx/event/tests/test_both.py
@@ -1029,7 +1029,7 @@ class Node(event.HasEvents):
                 self._r2.append('null')
 
 
-@run_in_both(Node, "[0, 0, 17, 18, 28, 29, null]")
+@run_in_both(Node, "[17, 18, 29]")
 def test_dynamism1(Node):
     n = Node()
     n1 = Node()
@@ -1057,8 +1057,8 @@ def test_dynamism1(Node):
     return n._r1
 
 
-@run_in_both(Node, "[0, 17, 18, 28, 29, null]")
-def test_dynamism2(Node):
+@run_in_both(Node, "[17, 18, 29]")
+def test_dynamism2a(Node):
     n = Node()
     n1 = Node()
     n2 = Node()
@@ -1095,7 +1095,45 @@ def test_dynamism2(Node):
     return res
 
 
-@run_in_both(Node, "['null', 'null', 17, 27, 18, 28, 'null', 29, 'null']")
+@run_in_both(Node, "[0, 17, 18, 28, 29, null]")
+def test_dynamism2b(Node):
+    n = Node()
+    n1 = Node()
+    n2 = Node()
+    
+    res = []
+    
+    def func(*events):
+        for ev in events:
+            if n.parent:
+                res.append(n.parent.val)
+            else:
+                res.append(None)
+    handler = n.connect(func, 'parent', 'parent.val')  # also connect to parent
+    
+    n.parent = n1
+    n.val = 42
+    handler.handle_now()
+    n1.val = 17
+    n2.val = 27
+    handler.handle_now()
+    n1.val = 18
+    n2.val = 28
+    handler.handle_now()
+    n.parent = n2
+    handler.handle_now()
+    n1.val = 19
+    n2.val = 29
+    handler.handle_now()
+    n.parent = None
+    handler.handle_now()
+    n1.val = 11
+    n2.val = 21
+    handler.handle_now()
+    return res
+
+
+@run_in_both(Node, "[17, 27, 18, 28, 29]")
 def test_dynamism3(Node):
     n = Node()
     n1 = Node()
@@ -1123,8 +1161,8 @@ def test_dynamism3(Node):
     return n._r2
 
 
-@run_in_both(Node, "['null', 17, 27, 18, 28, 'null', 29, 'null']")
-def test_dynamism4(Node):
+@run_in_both(Node, "[17, 27, 18, 28, 29]")
+def test_dynamism4a(Node):
     n = Node()
     n1 = Node()
     n2 = Node()
@@ -1138,6 +1176,44 @@ def test_dynamism4(Node):
             else:
                 res.append('null')
     handler = n.connect(func, 'children.*.val')
+    
+    n.children = n1, n2
+    n.val = 42
+    handler.handle_now()
+    n1.val = 17
+    n2.val = 27
+    handler.handle_now()
+    n1.val = 18
+    n2.val = 28
+    handler.handle_now()
+    n.children = (n2, )
+    handler.handle_now()
+    n1.val = 19
+    n2.val = 29
+    handler.handle_now()
+    n.children = ()
+    handler.handle_now()
+    n1.val = 11
+    n2.val = 21
+    handler.handle_now()
+    return res
+
+
+@run_in_both(Node, "['null', 17, 27, 18, 28, 'null', 29, 'null']")
+def test_dynamism4b(Node):
+    n = Node()
+    n1 = Node()
+    n2 = Node()
+    
+    res = []
+    
+    def func(*events):
+        for ev in events:
+            if isinstance(ev.new_value, (float, int)):
+                res.append(ev.new_value)
+            else:
+                res.append('null')
+    handler = n.connect(func, 'children', 'children.*.val')  # also connect children
     
     n.children = n1, n2
     n.val = 42

--- a/flexx/event/tests/test_both.py
+++ b/flexx/event/tests/test_both.py
@@ -536,6 +536,28 @@ def test_connect2(Person):
     return res
 
 
+@run_in_both(Person, "['jane', 'jansen', 'johnny', 1]")
+def test_connect3(Person):
+    res = []
+    res2 = []
+    def func(*events):
+        res2.append(1)
+        for ev in events:
+            res.append(ev.new_value)
+    
+    name = Person()
+    handler = name.connect('first_name', 'last_name', func)  # func can also come last
+    assert handler is not func
+    
+    name.first_name = 'jane'
+    name.last_name = 'jansen'
+    name.first_name = 'jane'
+    name.first_name = 'johnny'
+    handler.handle_now()
+    res.append(len(res2))
+    return res
+
+
 @run_in_both(Person, "['jane', 'jansen', '||', 'jane', 'jansen']")
 def test_disconnect_dispose(Person):
     res1 = []

--- a/flexx/event/tests/test_emitters.py
+++ b/flexx/event/tests/test_emitters.py
@@ -215,9 +215,11 @@ def test_emitter():
         def bar(self, v):
             return dict(value=float(v)+1)  # note plus 1
         
+        @event.connect('foo')
         def on_foo(self, *events):
             self.the_val = events[0].value  # so we can test it
         
+        @event.connect('bar')
         def on_bar(self, *events):
             self.the_val = events[0].value  # so we can test it
     

--- a/flexx/event/tests/test_handlers.py
+++ b/flexx/event/tests/test_handlers.py
@@ -145,6 +145,36 @@ def test_func_handlers_nodecorator():
     assert handle1.get_name() == '_handle1'  # note the name
 
 
+def test_func_handlers_nodecorator_reverse_connect_order():
+    
+    events1 = []
+    events2 = []
+    class Foo(event.HasEvents):
+        pass
+    
+    foo = Foo()
+    
+    def _handle1(*events):
+        events1.extend(events)
+    handle1 = foo.connect('x1', _handle1)
+    
+    def _handle2(*events):
+        events2.extend(events)
+    handle2 = foo.connect('x1', 'x2', _handle2)
+    
+    with event.loop:
+        foo.emit('x1', {})
+        foo.emit('x2', {})
+    
+    assert len(events1) == 1
+    assert len(events2) == 2
+    
+    assert isinstance(handle1, event._handler.Handler)
+    assert repr(handle1)
+    assert hasattr(handle1, 'dispose')
+    assert handle1.get_name() == '_handle1'  # note the name
+
+
 def test_func_handlers_with_method_decorator():
 
     @event.connect('x')

--- a/flexx/event/tests/test_hasevents.py
+++ b/flexx/event/tests/test_hasevents.py
@@ -97,6 +97,20 @@ def test_get_event_handlers():
         foo.get_event_handlers('x:a')
 
 
+def test_that_methods_starting_with_on_are_not_autoconverted():
+    # There is also a warning, but seems a bit of a fuzz to test
+    class Foo(event.HasEvents):
+        def on_foo(self, *events):
+            pass
+        @event.connect('bar')
+        def on_bar(self, *events):
+            pass
+    
+    foo = Foo()
+    assert isinstance(foo.on_bar, event.Handler)
+    assert not isinstance(foo.on_foo, event.Handler)
+
+
 def test_collect_classes():
     skip('we did not go the metaclass way')  # Not if we don't use the meta class
     class Foo123(event.HasEvents):

--- a/flexx/event/tests/test_hasevents.py
+++ b/flexx/event/tests/test_hasevents.py
@@ -48,6 +48,7 @@ def test_basics():
         @event.connect('x')
         def spam(self, *events):
             pass
+        @event.connect('eggs')
         def on_eggs(self, *events):
             pass
     #

--- a/flexx/event/tests/test_loop.py
+++ b/flexx/event/tests/test_loop.py
@@ -11,6 +11,7 @@ class Foo(event.HasEvents):
         super().__init__()
         self.r = []
     
+    @event.connect('foo')
     def on_foo(self, *events):
         self.r.append(len(events))
 

--- a/flexx/ui/examples/drawing.py
+++ b/flexx/ui/examples/drawing.py
@@ -5,7 +5,7 @@ This example demonstrates a simple drawing app. Useful for testing
 canvas and its mouse events.
 """
 
-from flexx import app, ui
+from flexx import app, ui, event
 
 
 class Drawing(ui.CanvasWidget):
@@ -21,7 +21,8 @@ class Drawing(ui.CanvasWidget):
             self.ctx = self.node.getContext('2d')
             self._last_ev = None
         
-        def on_mouse_move(self, *events):
+        @event.connect('mouse_move')
+        def on_move(self, *events):
             for ev in events:
                 last_ev = self._last_ev
                 if 1 in ev.buttons and last_ev is not None:
@@ -34,7 +35,8 @@ class Drawing(ui.CanvasWidget):
                     self.ctx.stroke()
                     self._last_ev = ev
         
-        def on_mouse_down(self, *events):
+        @event.connect('mouse_down')
+        def on_down(self, *events):
             for ev in events:
                 self.ctx.beginPath()
                 self.ctx.fillStyle = '#f00'
@@ -42,7 +44,8 @@ class Drawing(ui.CanvasWidget):
                 self.ctx.fill()
                 self._last_ev = ev
         
-        def on_mouse_up(self, *events):
+        @event.connect('mouse_up')
+        def on_up(self, *events):
             for ev in events:
                 self.ctx.beginPath()
                 self.ctx.fillStyle = '#00f'

--- a/flexx/ui/examples/monitor.py
+++ b/flexx/ui/examples/monitor.py
@@ -54,10 +54,12 @@ class Monitor(ui.Widget):
                 
                 self.cpu_plot = ui.PlotWidget(style='width: 640px; height: 320px;',
                                               xdata=[], yrange=(0, 100), 
-                                              ylabel='CPU usage (%)')
+                                              ylabel='CPU usage (%)',
+                                              sync_props=False)
                 self.mem_plot = ui.PlotWidget(style='width: 640px; height: 320px;',
                                               xdata=[], yrange=(0, 100), 
-                                              ylabel='Mem usage (%)')
+                                              ylabel='Mem usage (%)',
+                                              sync_props=False)
                 ui.Widget(flex=1)
         
         # Relay global info into this app
@@ -94,7 +96,7 @@ class Monitor(ui.Widget):
             
             # Prepare plots
             import time
-            times = self.cpu_plot.xdata
+            times = self.cpu_plot.xdata.copy()
             times.append(time.time() - self.start_time)
             times = times[-self.nsamples:]
             self.cpu_plot.xdata = times

--- a/flexx/ui/examples/with_bokeh.py
+++ b/flexx/ui/examples/with_bokeh.py
@@ -23,9 +23,9 @@ p1.scatter(x, y, alpha=0.1, nonselection_alpha=0.1)
 
 # Plot2
 t = np.linspace(0, 6.5, 100)
-p2 = figure(tools=TOOLS, responsive='width_ar')
+p2 = figure(tools=TOOLS, responsive='scale_width')
 p2.line(t, np.sin(t))
-p3 = figure(tools=TOOLS, responsive='width_ar')
+p3 = figure(tools=TOOLS, responsive='scale_width')
 p3.line(t, np.cos(t))
 
 class Example(ui.Widget):

--- a/flexx/ui/layouts/_box.py
+++ b/flexx/ui/layouts/_box.py
@@ -225,7 +225,7 @@ class BoxLayout(BaseBoxLayout):
         
         _DEFAULT_ORIENTATION = 'h'
         
-        @event.connect('orientation', 'children.*.flex')
+        @event.connect('orientation', 'children', 'children.*.flex')
         def __set_flexes(self, *events):
             ori = self.orientation
             i = 0 if ori in (0, 'h', 'hr') else 1
@@ -327,7 +327,7 @@ class BoxPanel(BaseBoxLayout):
             self.phosphor = window.phosphor.boxpanel.BoxPanel()
             self.node = self.phosphor.node
         
-        @event.connect('orientation', 'children.*.flex')
+        @event.connect('orientation', 'children', 'children.*.flex')
         def __set_flexes(self, *events):
             i = 0 if self.orientation in (0, 'h', 'hr') else 1
             for widget in self.children:

--- a/flexx/ui/layouts/_box.py
+++ b/flexx/ui/layouts/_box.py
@@ -116,24 +116,26 @@ class BaseBoxLayout(Layout):
     """ Base class for BoxLayout and BoxPanel.
     """
     
-    @event.prop(both=True)
-    def spacing(self, v=5):
-        """ The space between two child elements (in pixels)"""
-        return float(v)
-    
-    @event.prop(both=True)
-    def orientation(self, v=None):
-        """ The orientation of the child widgets. 'h' or 'v'. Default
-        horizontal. The items can also be reversed using 'hr' and 'vr'.
-        """
-        if v is None:
-            v = self._DEFAULT_ORIENTATION
-        if isinstance(v, str):
-            v = v.lower()
-        v = {'horizontal': 'h', 'vertical': 'v', 0: 'h', 1: 'v'}.get(v, v)
-        if v not in ('h', 'v', 'hr', 'vr'):
-            raise ValueError('Unknown value for box orientation %r' % v)
-        return v
+    class Both:
+        
+        @event.prop
+        def spacing(self, v=5):
+            """ The space between two child elements (in pixels)"""
+            return float(v)
+        
+        @event.prop
+        def orientation(self, v=None):
+            """ The orientation of the child widgets. 'h' or 'v'. Default
+            horizontal. The items can also be reversed using 'hr' and 'vr'.
+            """
+            if v is None:
+                v = self._DEFAULT_ORIENTATION
+            if isinstance(v, str):
+                v = v.lower()
+            v = {'horizontal': 'h', 'vertical': 'v', 0: 'h', 1: 'v'}.get(v, v)
+            if v not in ('h', 'v', 'hr', 'vr'):
+                raise ValueError('Unknown value for box orientation %r' % v)
+            return v
 
 
 class BoxLayout(BaseBoxLayout):
@@ -212,10 +214,12 @@ class BoxLayout(BaseBoxLayout):
     }
     """
     
-    @event.prop(both=True)
-    def padding(self, v=1):
-        """ The empty space around the layout (in pixels). """
-        return float(v)
+    class Both:
+        
+        @event.prop
+        def padding(self, v=1):
+            """ The empty space around the layout (in pixels). """
+            return float(v)
     
     class JS:
         

--- a/flexx/ui/layouts/_form.py
+++ b/flexx/ui/layouts/_form.py
@@ -221,13 +221,13 @@ class FormLayout(BaseTableLayout):
             if widget._title_elem:
                 del widget._title_elem
         
-        @event.connect('children.*.flex')
+        @event.connect('children', 'children.*.flex')
         def __update_flexes(self, *events):
             for widget in self.children:
                 widget.outernode.vflex = widget.flex[1]
             self._apply_table_layout()
         
-        @event.connect('children.*.title')
+        @event.connect('children', 'children.*.title')
         def __update_titles(self, *events):
             for widget in self.children:
                 if hasattr(widget, '_title_elem'):

--- a/flexx/ui/layouts/_grid.py
+++ b/flexx/ui/layouts/_grid.py
@@ -59,17 +59,19 @@ class GridPanel(Layout):
     def init(self):
         raise NotImplementedError('The GridPanel is (temporarily) deprecated.')
     
-    @event.prop(both=True)
-    def spacing(self, v=5):
-        """ The space between two child elements. """
-        return float(v)
-    
-    # todo: allow specifying flex, minSize etc. using an array of dicts?
-    # @event.prop(both=True)
-    # def col_specs(self, v=None):
-    #     """ The specification for the columns. If None, uses the 
-    #     """
-    #     return v
+    class Both:
+            
+        @event.prop
+        def spacing(self, v=5):
+            """ The space between two child elements. """
+            return float(v)
+        
+        # todo: allow specifying flex, minSize etc. using an array of dicts?
+        # @event.prop
+        # def col_specs(self, v=None):
+        #     """ The specification for the columns. If None, uses the 
+        #     """
+        #     return v
     
     class JS:
         

--- a/flexx/ui/layouts/_grid.py
+++ b/flexx/ui/layouts/_grid.py
@@ -88,7 +88,8 @@ class GridPanel(Layout):
             window.phosphor.messaging.installMessageFilter(self.phosphor,
                                                            LayoutNotifier())
         
-        @event.connect('children.*.pos', 'children.*.flex', 'children.*.base_size')
+        @event.connect('children', 'children.*.pos',
+                       'children.*.flex', 'children.*.base_size')
         def __update_positions(self, *events):
             self._child_limits_changed()
         

--- a/flexx/ui/layouts/_pinboard.py
+++ b/flexx/ui/layouts/_pinboard.py
@@ -41,7 +41,7 @@ class PinboardLayout(Layout):
             self.phosphor = window.phosphor.panel.Panel()
             self.node = self.phosphor.node
         
-        @event.connect('children.*.pos')
+        @event.connect('children', 'children.*.pos')
         def __pos_changed(self, *events):
             for child in self.children:
                 pos = child.pos
@@ -49,7 +49,7 @@ class PinboardLayout(Layout):
                 st.left = pos[0] + "px" if (pos[0] > 1) else pos[0] * 100 + "%"
                 st.top = pos[1] + "px" if (pos[1] > 1) else pos[1] * 100 + "%"
         
-        @event.connect('children.*.base_size')
+        @event.connect('children', 'children.*.base_size')
         def __size_changed(self, *events):
             for child in self.children:
                 size = child.base_size

--- a/flexx/ui/layouts/_split.py
+++ b/flexx/ui/layouts/_split.py
@@ -35,19 +35,21 @@ class SplitPanel(Layout):
     
     _DEFAULT_ORIENTATION = 'h'
     
-    @event.prop(both=True)
-    def orientation(self, v=None):
-        """ The orientation of the child widgets. 'h' or 'v'. Default
-        horizontal.
-        """
-        if v is None:
-            v = self._DEFAULT_ORIENTATION
-        if isinstance(v, str):
-            v = v.lower()
-        v = {'horizontal': 'h', 'vertical': 'v', 0: 'h', 1: 'v'}.get(v, v)
-        if v not in ('h', 'v'):
-            raise ValueError('Unknown value for splitter orientation %r' % v)
-        return v
+    class Both:
+    
+        @event.prop
+        def orientation(self, v=None):
+            """ The orientation of the child widgets. 'h' or 'v'. Default
+            horizontal.
+            """
+            if v is None:
+                v = self._DEFAULT_ORIENTATION
+            if isinstance(v, str):
+                v = v.lower()
+            v = {'horizontal': 'h', 'vertical': 'v', 0: 'h', 1: 'v'}.get(v, v)
+            if v not in ('h', 'v'):
+                raise ValueError('Unknown value for splitter orientation %r' % v)
+            return v
     
     class JS:
         

--- a/flexx/ui/layouts/_stack.py
+++ b/flexx/ui/layouts/_stack.py
@@ -42,7 +42,8 @@ class StackedPanel(Layout):
             """ The currently shown widget.
             """
             if not (v is None or isinstance(v, Widget)):
-                raise ValueError('The StackedPanel\'s current widget should be a Widget.')
+                raise ValueError("The StackedPanel's current widget " +
+                                 "should be a Widget.")
             return v
     
     class JS:

--- a/flexx/ui/layouts/_stack.py
+++ b/flexx/ui/layouts/_stack.py
@@ -35,13 +35,15 @@ class StackedPanel(Layout):
     """ A panel which shows only one of its children at a time.
     """
     
-    @event.prop(both=True)
-    def current(self, v=None):
-        """ The currently shown widget.
-        """
-        if not (v is None or isinstance(v, Widget)):
-            raise ValueError('The StackedPanel\'s current widget should be a Widget.')
-        return v
+    class Both:
+        
+        @event.prop
+        def current(self, v=None):
+            """ The currently shown widget.
+            """
+            if not (v is None or isinstance(v, Widget)):
+                raise ValueError('The StackedPanel\'s current widget should be a Widget.')
+            return v
     
     class JS:
         

--- a/flexx/ui/widgets/_bokeh.py
+++ b/flexx/ui/widgets/_bokeh.py
@@ -64,7 +64,7 @@ class BokehWidget(Widget):
                 filename = os.path.join(res, x, modname + x)
                 self.session.add_global_asset(modname + x, filename)
     
-    @event.prop(sync=False)
+    @event.prop
     def plot(self, plot=None):
         """ The Bokeh plot object to display. In JS, this prop
         provides the corresponding backbone model.
@@ -91,7 +91,7 @@ class BokehWidget(Widget):
     
     class JS:
         
-        @event.prop(sync=False)
+        @event.prop
         def plot(self, plot=None):
             return plot
         

--- a/flexx/ui/widgets/_bokeh.py
+++ b/flexx/ui/widgets/_bokeh.py
@@ -77,8 +77,9 @@ class BokehWidget(Widget):
             return None
         if not isinstance(plot, Plot):
             raise ValueError('Plot must be a Bokeh plot object.')
+        # Responsive is fixed by default, but that's silly in this context
         if plot.responsive == 'fixed':
-            plot.responsive = 'box'  # Fixed is default, but silly in this context
+            plot.responsive = 'stretch_both'
         self._plot_components(plot)
         return plot
     

--- a/flexx/ui/widgets/_button.py
+++ b/flexx/ui/widgets/_button.py
@@ -78,18 +78,20 @@ class BaseButton(Widget):
     
     """
     
-    @event.prop(both=True)
-    def text(self, v=''):
-        """ The text on the button.
-        """
-        return str(v)
-    
-    @event.prop(both=True)
-    def checked(self, v=False):
-        """ Whether the button is checked. Applicable for CheckBox,
-        RadioButton and ToggleButton.
-        """
-        return bool(v)
+    class Both:
+            
+        @event.prop
+        def text(self, v=''):
+            """ The text on the button.
+            """
+            return str(v)
+        
+        @event.prop
+        def checked(self, v=False):
+            """ Whether the button is checked. Applicable for CheckBox,
+            RadioButton and ToggleButton.
+            """
+            return bool(v)
     
     class JS:
         

--- a/flexx/ui/widgets/_color.py
+++ b/flexx/ui/widgets/_color.py
@@ -30,13 +30,15 @@ class ColorSelectWidget(Widget):
     on Firefox and Chrome, but not on IE/Edge last time I checked.
     """
     
-    @event.prop(both=True)
-    def color(self, v='#000000'):
-        """ The currently selected color.
-        """
-        if not (v.startswith('#') and len(v) == 7):
-            raise ValueError('ColorSelectWidget must be in #rrggbb format.')
-        return str(v)
+    class Both:
+            
+        @event.prop
+        def color(self, v='#000000'):
+            """ The currently selected color.
+            """
+            if not (v.startswith('#') and len(v) == 7):
+                raise ValueError('ColorSelectWidget must be in #rrggbb format.')
+            return str(v)
     
     class JS:
     

--- a/flexx/ui/widgets/_iframe.py
+++ b/flexx/ui/widgets/_iframe.py
@@ -23,15 +23,17 @@ class IFrame(Widget):
     
     CSS = '.flx-IFrame {border: none;}'
     
-    @event.prop(both=True)
-    def url(self, v=''):
-        """ The url to show. 'http://' is automatically prepended if the url
-        does not have '://' in it.
-        """
-        v = str(v)
-        if v and '://' not in v:
-            v = 'http://' + v
-        return v
+    class Both:
+        
+        @event.prop
+        def url(self, v=''):
+            """ The url to show. 'http://' is automatically prepended if the url
+            does not have '://' in it.
+            """
+            v = str(v)
+            if v and '://' not in v:
+                v = 'http://' + v
+            return v
     
     class JS:
         

--- a/flexx/ui/widgets/_label.py
+++ b/flexx/ui/widgets/_label.py
@@ -44,19 +44,21 @@ class Label(Widget):
             -ms-user-select: text;
         }"""
     
-    @event.prop(both=True)
-    def text(self, v=''):
-        """ The text on the label.
-        """
-        return str(v)
-    
-    @event.prop(both=True)
-    def wrap(self, v=False):
-        """ Whether the content is allowed to be wrapped on multiple
-        lines. Set to 0/False for no wrap, 1/True for word-wrap, 2 for
-        character wrap.
-        """
-        return {0: 0, 1: 1, 2: 2}.get(v, int(bool(v)))
+    class Both:
+            
+        @event.prop
+        def text(self, v=''):
+            """ The text on the label.
+            """
+            return str(v)
+        
+        @event.prop
+        def wrap(self, v=False):
+            """ Whether the content is allowed to be wrapped on multiple
+            lines. Set to 0/False for no wrap, 1/True for word-wrap, 2 for
+            character wrap.
+            """
+            return {0: 0, 1: 1, 2: 2}.get(v, int(bool(v)))
     
     class JS:
         

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -44,29 +44,31 @@ class LineEdit(Widget):
     }
     """
     
-    @event.prop(both=True)
-    def text(self, v=''):
-        """ The current text."""
-        return str(v)
-    
-    @event.prop(both=True)
-    def password_mode(self, v=False):
-        """ Whether the insered text should be hidden or not.
-        """
-        return bool(v)
-    
-    @event.prop(both=True)
-    def placeholder_text(self, v=''):
-        """ The placeholder text (shown when the text is an empty string)."""
-        return str(v)
-    
-    @event.prop(both=True)
-    def autocomp(self, v=()):
-        """ A tuple/list of strings for autocompletion. Might not work
-        in all browsers.
-        """
-        return tuple([str(i) for i in v])
-    
+    class Both:
+            
+        @event.prop
+        def text(self, v=''):
+            """ The current text."""
+            return str(v)
+        
+        @event.prop
+        def password_mode(self, v=False):
+            """ Whether the insered text should be hidden or not.
+            """
+            return bool(v)
+        
+        @event.prop
+        def placeholder_text(self, v=''):
+            """ The placeholder text (shown when the text is an empty string)."""
+            return str(v)
+        
+        @event.prop
+        def autocomp(self, v=()):
+            """ A tuple/list of strings for autocompletion. Might not work
+            in all browsers.
+            """
+            return tuple([str(i) for i in v])
+        
     class JS:
     
         def _init_phosphor_and_node(self):

--- a/flexx/ui/widgets/_media.py
+++ b/flexx/ui/widgets/_media.py
@@ -49,27 +49,29 @@ class ImageWidget(Widget):
     """ Display an image using a url.
     """
     
-    @event.prop(both=True)
-    def source(self, v=''):
-        """ The source of the image, This can be anything that an HTML
-        img element supports. Also supported are images on the server,
-        these will be added as assets so the client can request them.
-        """
-        if not this_is_js():
-            # Is it an image on the server that we need to serve up?
-            if v.endswith(('.png', '.jpg', '.svg', '.gif')):
-                if os.path.isfile(v):
-                    fname = self.id + os.path.splitext(v)[1]
-                    app.assets.add_asset(fname, v)
-                    return fname
-        return str(v)
-    
-    @event.prop(both=True)
-    def stretch(self, v=False):
-        """ Whether the image should stretch to fill all available
-        space, or maintain its aspect ratio (default).
-        """
-        return bool(v)
+    class Both:
+            
+        @event.prop
+        def source(self, v=''):
+            """ The source of the image, This can be anything that an HTML
+            img element supports. Also supported are images on the server,
+            these will be added as assets so the client can request them.
+            """
+            if not this_is_js():
+                # Is it an image on the server that we need to serve up?
+                if v.endswith(('.png', '.jpg', '.svg', '.gif')):
+                    if os.path.isfile(v):
+                        fname = self.id + os.path.splitext(v)[1]
+                        app.assets.add_asset(fname, v)
+                        return fname
+            return str(v)
+        
+        @event.prop
+        def stretch(self, v=False):
+            """ Whether the image should stretch to fill all available
+            space, or maintain its aspect ratio (default).
+            """
+            return bool(v)
     
     class JS:
         
@@ -101,12 +103,14 @@ class VideoWidget(Widget):
     """ A widget to display a video from a url.
     """
     
-    @event.prop(both=True)
-    def source(self, v=''):
-        """ The source of the video. This must be a url of a resource
-        on the web.
-        """
-        return str(v)
+    class Both:
+            
+        @event.prop
+        def source(self, v=''):
+            """ The source of the video. This must be a url of a resource
+            on the web.
+            """
+            return str(v)
     
     class JS:
         
@@ -130,11 +134,13 @@ class YoutubeWidget(Widget):
     """ A widget to display a Youtube video.
     """
     
-    @event.prop(both=True)
-    def source(self, v='oHg5SJYRHA0'):
-        """ The source of the video represented as the Youtube id.
-        """
-        return str(v)
+    class Both:
+            
+        @event.prop
+        def source(self, v='oHg5SJYRHA0'):
+            """ The source of the video represented as the Youtube id.
+            """
+            return str(v)
     
     class JS:
         

--- a/flexx/ui/widgets/_plotwidget.py
+++ b/flexx/ui/widgets/_plotwidget.py
@@ -58,57 +58,59 @@ class PlotWidget(CanvasWidget):
     
     CSS = ".flx-PlotWidget {min-width: 300px; min-height: 200px;}"
     
-    @event.prop(both=True)
-    def xdata(self, v=()):
-        """ A list of values for the x-axis. """
-        return [float(f) for f in v]
-    
-    @event.prop(both=True)
-    def ydata(self, v=()):
-        """ A list of values for the y-axis. """
-        return [float(f) for f in v]
-    
-    @event.prop(both=True)
-    def yrange(self, v=None):
-        """ The range for the y-axis. If None (default) it is determined
-        from the data. """
-        if v is not None:
-            v = tuple([float(f) for f in v])
-            assert len(v) == 2
-        return v
-    
-    @event.prop(both=True)
-    def line_color(self, v='blue'):
-        """ The color of the line. If this is the empty string, the
-        line is not shown. """
-        return str(v)
-    
-    # todo: allow setting alpha as #rrggbbaa and #rgba
-    @event.prop(both=True)
-    def marker_color(self, v='blue'):
-        """ The color of the marker. If this is the empty string, the
-        line is not shown. """
-        return str(v)
-    
-    @event.prop(both=True)
-    def line_width(self, v=2):
-        """ The width of the line, in pixels. """
-        return float(v)
-    
-    @event.prop(both=True)
-    def marker_size(self, v=6):
-        """ The size of the marker, in pixels. """
-        return float(v)
-    
-    @event.prop(both=True)
-    def xlabel(self, v=''):
-        """ The label to show on the x-axis. """
-        return str(v)
-    
-    @event.prop(both=True)
-    def ylabel(self, v=''):
-        """ The label to show on the y-axis. """
-        return str(v)
+    class Both:
+            
+        @event.prop
+        def xdata(self, v=()):
+            """ A list of values for the x-axis. """
+            return [float(f) for f in v]
+        
+        @event.prop
+        def ydata(self, v=()):
+            """ A list of values for the y-axis. """
+            return [float(f) for f in v]
+        
+        @event.prop
+        def yrange(self, v=None):
+            """ The range for the y-axis. If None (default) it is determined
+            from the data. """
+            if v is not None:
+                v = tuple([float(f) for f in v])
+                assert len(v) == 2
+            return v
+        
+        @event.prop
+        def line_color(self, v='blue'):
+            """ The color of the line. If this is the empty string, the
+            line is not shown. """
+            return str(v)
+        
+        # todo: allow setting alpha as #rrggbbaa and #rgba
+        @event.prop
+        def marker_color(self, v='blue'):
+            """ The color of the marker. If this is the empty string, the
+            line is not shown. """
+            return str(v)
+        
+        @event.prop
+        def line_width(self, v=2):
+            """ The width of the line, in pixels. """
+            return float(v)
+        
+        @event.prop
+        def marker_size(self, v=6):
+            """ The size of the marker, in pixels. """
+            return float(v)
+        
+        @event.prop
+        def xlabel(self, v=''):
+            """ The label to show on the x-axis. """
+            return str(v)
+        
+        @event.prop
+        def ylabel(self, v=''):
+            """ The label to show on the y-axis. """
+            return str(v)
     
     class JS:
         

--- a/flexx/ui/widgets/_plotwidget.py
+++ b/flexx/ui/widgets/_plotwidget.py
@@ -127,8 +127,10 @@ class PlotWidget(CanvasWidget):
         @event.connect('xdata', 'ydata', 'yrange', 'line_color', 'line_width',
                        'marker_color', 'marker_size', 'xlabel', 'ylabel',
                        'title', 'size')
-        def _update_plot(self, *events):
+        def update(self, *events):
+            window.requestAnimationFrame(self._update)
             
+        def _update(self):
             xx, yy = self.xdata, self.ydata
             yrange = self.yrange
             lc, lw = self.line_color, self.line_width

--- a/flexx/ui/widgets/_progressbar.py
+++ b/flexx/ui/widgets/_progressbar.py
@@ -43,17 +43,19 @@ class ProgressBar(Widget):
     
     CSS = ".flx-ProgressBar {min-height: 10px;}"
     
-    @event.prop(both=True)
-    def value(self, v=0):
-        """ The progress value.
-        """
-        return float(v)
-    
-    @event.prop(both=True)
-    def max(self, v=1):
-        """ The maximum progress value.
-        """
-        return float(v)
+    class Both:
+            
+        @event.prop
+        def value(self, v=0):
+            """ The progress value.
+            """
+            return float(v)
+        
+        @event.prop
+        def max(self, v=1):
+            """ The maximum progress value.
+            """
+            return float(v)
     
     class JS:
     

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -40,25 +40,27 @@ class Slider(Widget):
     
     CSS = ".flx-Slider {min-height: 30px;}"
     
-    @event.prop(both=True)
-    def step(self, v=0.01):
-        """ The step size for the slider."""
-        return float(v)
-    
-    @event.prop(both=True)
-    def min(self, v=0):
-        """ The minimal slider value."""
-        return float(v)
-    
-    @event.prop(both=True)
-    def max(self, v=1):
-        """ The maximum slider value."""
-        return float(v)
-    
-    @event.prop(both=True)
-    def value(self, v=0):
-        """ The current slider value (settable)."""
-        return float(v)
+    class Both:
+            
+        @event.prop
+        def step(self, v=0.01):
+            """ The step size for the slider."""
+            return float(v)
+        
+        @event.prop
+        def min(self, v=0):
+            """ The minimal slider value."""
+            return float(v)
+        
+        @event.prop
+        def max(self, v=1):
+            """ The maximum slider value."""
+            return float(v)
+        
+        @event.prop
+        def value(self, v=0):
+            """ The current slider value (settable)."""
+            return float(v)
     
     class JS:
         


### PR DESCRIPTION
This PR makes some changes to the new event system, based on the experience with it so far. Many of these will (again) brake compatibility, so this needs to be in master before a next release. Also combining in one PR so that we break backwards compatibility once, instead of for each change.

* [x] closes #124 - `def on_foo` does no longer create a handler implicitly
* [x] handlers can now use `super()` to invoke their superclass version.
* [x]  #129 `emit()` can be called without specifying a dict.
* [x] #123 use `Both` subclass instead of property flags
* [x] `connect(func, 'foo')` and `connect('foo', func)` now both work.
* [x] Accidentally snuck in fixes for latest Bokeh (to be released soon)
* [x] #120 
* [x] #112