### PR TITLE
Add create_server(new_loop=True), and rename current_server

### DIFF
--- a/docs/app/api.rst
+++ b/docs/app/api.rst
@@ -17,7 +17,7 @@ Functions related to the event loop
 
 .. autofunction:: flexx.app.create_server
 
-.. autofunction:: flexx.app.get_current_server
+.. autofunction:: flexx.app.current_server
 
 
 Functions related to us Model classes as apps

--- a/flexx/app/__init__.py
+++ b/flexx/app/__init__.py
@@ -86,7 +86,7 @@ del logging
 from .session import manager, Session
 from .model import Model, get_active_model
 from .model import get_instance_by_id, get_model_classes
-from .funcs import create_server, get_current_server, run, start, stop, call_later
+from .funcs import create_server, current_server, run, start, stop, call_later
 from .funcs import init_notebook, serve, launch, export
 from .assetstore import assets
 from .clientcore import FlexxJS

--- a/flexx/app/examples/adding_handlers.py
+++ b/flexx/app/examples/adding_handlers.py
@@ -40,7 +40,7 @@ class MyAPIHandler(tornado.web.RequestHandler):
 
 
 # Get a ref to the tornado.web.Application object
-tornado_app = app.get_current_server().app
+tornado_app = app.current_server().app
 
 # Add our handler
 tornado_app.add_handlers(r".*", [(r"/about", MyAboutHandler),

--- a/flexx/app/examples/flexx_in_thread.py
+++ b/flexx/app/examples/flexx_in_thread.py
@@ -7,10 +7,10 @@ should generally only be done from a single thread. Event handlers
 are *always* called from the same thread that runs the event loop
 (unless manually called).
 
-The app.create_server() is used to (re)create the server object, binding
-it to the ioloop of the current thread. Note that app.start() must be
-called from that same thread.
-
+The app.create_server() is used to (re)create the server object. It is
+important that the used IOLoop is local to the thread. This can be
+accomplished by calling create_server() and start() from the same
+thread, or using ``new_loop=True`` (as is done here).
 """
 
 import time
@@ -32,13 +32,9 @@ class MyModel1(event.HasEvents):
 # Create model in main thread
 model = MyModel1()
 
-def main():
-    app.create_server()
-    model.foo = 2  # Probably a bad idea to set props from both threads
-    app.start()
-
-# Start Flexx server in new thread
-t = threading.Thread(target=main)
+# Start server in its own thread
+app.create_server(new_loop=True)
+t = threading.Thread(target=app.start)
 t.start()
 
 # Manipulate model from main thread (the model's on_foo() gets called from other thread)

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -23,7 +23,7 @@ reprs = json.dumps
 _current_server = None
 
 
-def create_server(host=None, port=None, backend='tornado'):
+def create_server(host=None, port=None, new_loop=False, backend='tornado'):
     """
     Create a new server object. This is automatically called; for common
     use this is not needed.
@@ -39,10 +39,13 @@ def create_server(host=None, port=None, backend='tornado'):
         port (int, str): The port number. If a string is given, it is
             hashed to an ephemeral port number. By default
             ``flexx.config.hostname`` is used.
+        new_loop (bool): Whether to create a fresh Tornado IOLoop instance,
+            which is made current when ``start()`` is called. If ``False``
+            (default) will use the current IOLoop for this thread.
         backend (str): Stub argument; only Tornado is currently supported.
     
     Returns:
-        server: The server object, see ``get_current_server()``.
+        server: The server object, see ``current_server()``.
     """
     global _current_server
     if backend.lower() != 'tornado':
@@ -56,11 +59,11 @@ def create_server(host=None, port=None, backend='tornado'):
     if _current_server:
         _current_server.close()
     # Start hosting
-    _current_server = TornadoServer(host, port)
+    _current_server = TornadoServer(host, port, new_loop)
     return _current_server
 
 
-def get_current_server():
+def current_server():
     """
     Get the current server object. Creates a server if there is none.
     Currently, this is always a TornadoServer object, which has properties:
@@ -84,7 +87,7 @@ def start():
     explicitly called, ``start()`` must be called from the same thread,
     otherwise an error is raised.
     """
-    server = get_current_server()
+    server = current_server()
     logger.info('Starting Flexx event loop.')
     server.start()
 
@@ -94,7 +97,7 @@ def run():
     Start the event loop in desktop app mode; the server will close
     down when there are no more connections.
     """
-    server = get_current_server()
+    server = current_server()
     server._auto_stop = True
     return start()
 
@@ -107,7 +110,7 @@ def stop():
     calling ``stop()`` too often will cause a subsequent call to `start()``
     to return almost immediately.
     """
-    server = get_current_server()
+    server = current_server()
     server.stop()
 
 
@@ -122,7 +125,7 @@ def call_later(delay, callback, *args, **kwargs):
         args: the positional arguments to call the callback with.
         kwargs: the keyword arguments to call the callback with.
     """
-    server = get_current_server()
+    server = current_server()
     server.call_later(delay, callback, *args, **kwargs)
 
 
@@ -130,12 +133,12 @@ def call_later(delay, callback, *args, **kwargs):
 model.call_later = call_later
 
 # Integrate the "event-loop" of flexx.event
-_loop.loop.integrate(lambda f: get_current_server().call_later(0, f))
+_loop.loop.integrate(lambda f: current_server().call_later(0, f))
 
 
 @manager.connect('connections_changed')
 def _auto_closer(*events):
-    server = get_current_server()
+    server = current_server()
     if not getattr(server, '_auto_stop', False):
         return
     for name in manager.get_app_names():
@@ -169,7 +172,7 @@ def _deprecated_init_interactive(runtime=None, **runtime_kwargs):
         session._set_app(ui.Widget(is_app=True))
     
     # Launch web runtime, the server will wait for the connection
-    server = get_current_server()
+    server = current_server()
     host, port = server.serving
     if runtime == 'nodejs':
         all_js = session.get_js_only()
@@ -261,7 +264,7 @@ def init_notebook():
     
     # Open server - the notebook helper takes care of the JS resulting
     # from running a cell, but any interaction goes over the websocket.
-    server = get_current_server()
+    server = current_server()
     host, port = server.serving
     asset_elements = session.get_assets_as_html()
     
@@ -317,7 +320,7 @@ def launch(cls, runtime=None, **runtime_kwargs):
     session = manager.create_session(cls.__name__)
     
     # Launch web runtime, the server will wait for the connection
-    server = get_current_server()
+    server = current_server()
     host, port = server.serving
     if runtime == 'nodejs':
         all_js = session.get_js_only()

--- a/flexx/app/tests/test_live.py
+++ b/flexx/app/tests/test_live.py
@@ -23,11 +23,9 @@ TIMEOUT2 = 1.0
 def runner(cls):
     
     # Run with a fresh server
-    loop = tornado.ioloop.IOLoop()
-    loop.make_current()
-    app.create_server(port=0)
+    server = app.create_server(port=0, new_loop=True)
     
-    t = app.launch(cls, 'xul')  # fails somehow with XUL
+    t = app.launch(cls, 'xul')
     t.test_init()
     t.test_set_result()
     # Install failsafe. Use a closure so failsafe wont spoil a future test

--- a/flexx/app/tests/test_model.py
+++ b/flexx/app/tests/test_model.py
@@ -196,9 +196,7 @@ def test_get_instance_by_id():
 
 def test_active_models():
     
-    ioloop = tornado.ioloop.IOLoop()
-    ioloop.make_current()
-    app.create_server(port=0)
+    ioloop = app.create_server(port=0, new_loop=True).loop
     
     # This test needs a default session
     session = app.manager.get_default_session()

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -7,6 +7,7 @@ import json
 import time
 import socket
 import traceback
+import threading
 from urllib.parse import urlparse
 # from concurrent.futures import ThreadPoolExecutor
 
@@ -29,6 +30,11 @@ if tornado.version_info < (4, ):
 
 # Use a binary websocket or not?
 BINARY = False
+
+
+def is_main_thread():
+    """ Get whether this is the main thread. """
+    return isinstance(threading.current_thread(), threading._MainThread)
 
 
 class AbstractServer:
@@ -101,16 +107,25 @@ class TornadoServer(AbstractServer):
     """ Flexx Server implemented in Tornado.
     """
     
+    def __init__(self, host, port, new_loop):
+        self._new_loop = new_loop
+        super().__init__(host, port)
+    
     def _open(self, host, port):
         
-        # Get the current ioloop for the current thread
-        self._loop = tornado.ioloop.IOLoop.current()
+        # Get a new ioloop or the current ioloop for this thread
+        if self._new_loop:
+            self._loop = IOLoop()
+        else:
+            self._loop = IOLoop.current(is_main_thread())
+            if self._loop is None:
+                self._loop = IOLoop(make_current=True)
         
         # Create tornado application
         self._app = tornado.web.Application([(r"/(.*)/ws", WSHandler), 
                                              (r"/(.*)", MainHandler), ])
-        # Create tornado server. It will bind to the ioloop on calling listen or 
-        self._server = tornado.httpserver.HTTPServer(self._app)
+        # Create tornado server, bound to our own ioloop
+        self._server = tornado.httpserver.HTTPServer(self._app, io_loop=self._loop)
         
         # Start server (find free port number if port not given)
         if port:
@@ -141,13 +156,15 @@ class TornadoServer(AbstractServer):
         logger.info('Serving apps at http://%s:%i/' % (host, port))
     
     def _start(self):
-        # Start event loop - make use of the semi-standard defined by IPython
-        # to determine if the ioloop is "hijacked" (e.g. in Pyzo).
-        # There is no public way to determine if a loop is already running,
-        # but the AbstractServer class keeps track of this.
-        loop = IOLoop.current()
-        if loop is not self._loop:
-            raise RuntimeError('Server must start from same thread it was created in.')
+        # Ensure that our loop is the current loop for this thread
+        if self._new_loop:
+            self._loop.make_current()
+        elif IOLoop.current(is_main_thread()) is not self._loop:
+            raise RuntimeError('Server must use ioloop that is current to this thread.')
+        # Make use of the semi-standard defined by IPython to determine
+        # if the ioloop is "hijacked" (e.g. in Pyzo). There is no public
+        # way to determine if a loop is already running, but the
+        # AbstractServer class keeps track of this.
         if not getattr(self._loop, '_in_event_loop', False):
             self._loop.start()
     

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -117,7 +117,7 @@ class TornadoServer(AbstractServer):
         if self._new_loop:
             self._loop = IOLoop()
         else:
-            self._loop = IOLoop.current(is_main_thread())
+            self._loop = IOLoop.current(instance=is_main_thread())
             if self._loop is None:
                 self._loop = IOLoop(make_current=True)
         
@@ -159,7 +159,7 @@ class TornadoServer(AbstractServer):
         # Ensure that our loop is the current loop for this thread
         if self._new_loop:
             self._loop.make_current()
-        elif IOLoop.current(is_main_thread()) is not self._loop:
+        elif IOLoop.current(instance=is_main_thread()) is not self._loop:
             raise RuntimeError('Server must use ioloop that is current to this thread.')
         # Make use of the semi-standard defined by IPython to determine
         # if the ioloop is "hijacked" (e.g. in Pyzo). There is no public


### PR DESCRIPTION
Follow-up on #153 

This makes it possible to do:
```python
server = app.create_server(new_loop=True)
# do stuff with server.serving and server.app
t = threading.Thread(target=app.start)
t.start()
```

Also renamed `app.get_current_thread()` -> `app.current_thread()`

cc @korijn @Maxyme
