### PR TITLE
Make super work for emitters

### DIFF
--- a/flexx/app/tests/test_live.py
+++ b/flexx/app/tests/test_live.py
@@ -340,19 +340,19 @@ def test_generated_javascript():
     
     codeA, codeB = ModelA.JS.CODE, ModelB.JS.CODE
     
-    assert codeA.count('_foo1_func = function') == 1
-    assert codeA.count('_foo2_func = function') == 1
-    assert codeA.count('_foo3_func = function') == 0
-    assert codeA.count('_bar1_func = function') == 1
-    assert codeA.count('_bar2_func = function') == 1
-    assert codeA.count('_bar3_func = function') == 0
+    assert codeA.count('.foo1 = function') == 1
+    assert codeA.count('.foo2 = function') == 1
+    assert codeA.count('.foo3 = function') == 0
+    assert codeA.count('.bar1 = function') == 1
+    assert codeA.count('.bar2 = function') == 1
+    assert codeA.count('.bar3 = function') == 0
     
-    assert codeB.count('_foo1_func = function') == 0
-    assert codeB.count('_foo2_func = function') == 1
-    assert codeB.count('_foo3_func = function') == 1
-    assert codeB.count('_bar1_func = function') == 0
-    assert codeB.count('_bar2_func = function') == 1
-    assert codeB.count('_bar3_func = function') == 1
+    assert codeB.count('.foo1 = function') == 0
+    assert codeB.count('.foo2 = function') == 1
+    assert codeB.count('.foo3 = function') == 1
+    assert codeB.count('.bar1 = function') == 0
+    assert codeB.count('.bar2 = function') == 1
+    assert codeB.count('.bar3 = function') == 1
 
 
 def test_apps():

--- a/flexx/app/tests/test_model.py
+++ b/flexx/app/tests/test_model.py
@@ -168,13 +168,13 @@ def test_emitters_in_JS():
 
 
 def test_no_duplicate_code():
-    assert '_blue_func' in Foo1.JS.CODE
-    assert '_blue_func' not in Foo2.JS.CODE
-    assert '_blue_func' not in Foo4.JS.CODE
+    assert '.blue.' in Foo1.JS.CODE
+    assert '.blue.' not in Foo2.JS.CODE
+    assert '.blue.' not in Foo4.JS.CODE
     
-    assert '_red_func' not in Foo1.JS.CODE
-    assert '_red_func' in Foo2.JS.CODE
-    assert '_red_func' in Foo4.JS.CODE
+    assert '.red.' not in Foo1.JS.CODE
+    assert '.red.' in Foo2.JS.CODE
+    assert '.red.' in Foo4.JS.CODE
 
 
 def test_get_instance_by_id():

--- a/flexx/event/_emitters.py
+++ b/flexx/event/_emitters.py
@@ -146,6 +146,10 @@ class Emitter(BaseEmitter):
     def __get__(self, instance, owner):
         if instance is None:
             return self
-        func = instance._get_emitter(self._name)
+        #func = instance._get_emitter(self._name, self._func)
+        def func(*args):
+            ev = self._func(instance, *args)
+            if ev is not None:  # this protects against sending multiple events when using super
+                instance.emit(self._name, ev)
         func.__doc__ = self.__doc__
         return func

--- a/flexx/event/_emitters.py
+++ b/flexx/event/_emitters.py
@@ -98,6 +98,11 @@ class BaseEmitter:
     def __repr__(self):
         cls_name = self.__class__.__name__
         return '<%s for %s at 0x%x>' % (cls_name, self._name, id(self))
+    
+    def get_func(self):
+        """ Get the corresponding function object.
+        """
+        return self._func
 
 
 class Property(BaseEmitter):
@@ -111,7 +116,7 @@ class Property(BaseEmitter):
         self._defaults = inspect.getargspec(self._func).defaults
     
     def __set__(self, instance, value):
-        if isinstance is not None:  # pragma: no cover
+        if instance is not None:  # pragma: no cover
             return instance._set_prop(self._name, value)
     
     def __delete__(self, instance):
@@ -120,7 +125,6 @@ class Property(BaseEmitter):
     def __get__(self, instance, owner):
         if instance is None:
             return self
-        
         private_name = '_' + self._name + self._SUFFIX
         return getattr(instance, private_name)
 
@@ -146,10 +150,9 @@ class Emitter(BaseEmitter):
     def __get__(self, instance, owner):
         if instance is None:
             return self
-        #func = instance._get_emitter(self._name, self._func)
-        def func(*args):
+        def func(*args):  # this func should return None, so super() works correct
             ev = self._func(instance, *args)
-            if ev is not None:  # this protects against sending multiple events when using super
+            if ev is not None:
                 instance.emit(self._name, ev)
         func.__doc__ = self.__doc__
         return func

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -74,6 +74,7 @@ def finalize_hasevents_class(cls):
                 logger.warn('Method %r is not (anymore) converted to a '
                             'handler (on %s).' % (name, cls.__name__))
     
+    # todo: can we ditch this?
     # Finalize all found emitters
     for collection in (handlers, emitters, properties):
         for name, descriptor in collection.items():
@@ -319,17 +320,19 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             self.emit(prop_name, dict(new_value=value2, old_value=old))
             return True
     
-    def _get_emitter(self, emitter_name):
-        # Get an emitter function.
-        func_name = '_' + emitter_name + '_func'
-        func = getattr(self, func_name)
-        def emitter_func(*args):
-            if this_is_js():
-                ev = func.apply(self, args)
-            else:
-                ev = func(*args)
-            self.emit(emitter_name, ev)
-        return emitter_func
+    # def _get_emitter(self, emitter_name, func):
+    #     # Get an emitter function.
+    #     #func_name = '_' + emitter_name + '_func'
+    #     #func = getattr(self, func_name)
+    #     
+    #     def emitter_func(*args):
+    #         print('emitter_func(*args):', args)
+    #         if this_is_js():
+    #             ev = func.apply(self, args)
+    #         else:
+    #             ev = func(self, *args)
+    #         self.emit(emitter_name, ev)
+    #     return emitter_func
     
     def get_event_types(self):
         """ Get the known event types for this HasEvent object. Returns

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -74,12 +74,6 @@ def finalize_hasevents_class(cls):
                 logger.warn('Method %r is not (anymore) converted to a '
                             'handler (on %s).' % (name, cls.__name__))
     
-    # todo: can we ditch this?
-    # Finalize all found emitters
-    for collection in (handlers, emitters, properties):
-        for name, descriptor in collection.items():
-            descriptor._name = name
-            setattr(cls, '_' + name + '_func', descriptor._func)
     # Cache prop names
     cls.__handlers__ = [name for name in sorted(handlers.keys())]
     cls.__emitters__ = [name for name in sorted(emitters.keys())]
@@ -149,14 +143,15 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         # Initialize properties with default and given values (does not emit yet)
         for name in self.__properties__:
             self.__handlers.setdefault(name, [])
-            setattr(self, '_' + name + '_value', None)  # need *something*
+            setattr(self, '_' + name + '_value', None)  # need *something* for value
+            func = getattr(self.__class__, name).get_func()
+            setattr(self, '_' + name + '_func', func)  # needed in set_prop()
         for name in self.__properties__:
             dd = getattr(self.__class__, name)._defaults
             if dd:
                 self._set_prop(name, dd[0], True)
         for name, value in property_values.items():
             if name in self.__properties__:
-                #self._set_prop(name, value)
                 setattr(self, name, value)  # should raises error whith readonly
             else:
                 cname = self.__class__.__name__
@@ -290,7 +285,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             return
         # Prepare
         private_name = '_' + prop_name + '_value'
-        func_name = '_' + prop_name + '_func'
+        func_name = '_' + prop_name + '_func'  # set in init in both Py and JS
         # Validate value
         self.__props_being_set[prop_name] = True
         func = getattr(self, func_name)
@@ -298,7 +293,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             if this_is_js():
                 value2 = func.apply(self, [value])
             else:
-                value2 = func(value)
+                value2 = func(self, value)
         finally:
             self.__props_being_set[prop_name] = False
         # If not initialized yet, set
@@ -319,20 +314,6 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             setattr(self, private_name, value2)
             self.emit(prop_name, dict(new_value=value2, old_value=old))
             return True
-    
-    # def _get_emitter(self, emitter_name, func):
-    #     # Get an emitter function.
-    #     #func_name = '_' + emitter_name + '_func'
-    #     #func = getattr(self, func_name)
-    #     
-    #     def emitter_func(*args):
-    #         print('emitter_func(*args):', args)
-    #         if this_is_js():
-    #             ev = func.apply(self, args)
-    #         else:
-    #             ev = func(self, *args)
-    #         self.emit(emitter_name, ev)
-    #     return emitter_func
     
     def get_event_types(self):
         """ Get the known event types for this HasEvent object. Returns

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -48,8 +48,9 @@ class HasEventsJS:
         for name in self.__properties__:
             self.__handlers.setdefault(name, [])
             self['_' + name + '_value'] = None  # need *something*
+            self['_' + name + '_func'] = self[name]  # need below and in set_prop()
         for name in self.__properties__:
-            func = self[name]  # self['_' + name + '_func']
+            func = self['_' + name + '_func']
             creator = self['__create_' + func.emitter_type]
             creator(name)
             if func.default is not undefined:
@@ -58,8 +59,8 @@ class HasEventsJS:
         # Create emitters
         for name in self.__emitters__:
             self.__handlers.setdefault(name, [])
-            func = self[name]  #['_' + name + '_func']
-            self.__create_Emitter(name)
+            func = self[name]
+            self.__create_Emitter(func, name)
         
         # Init handlers and properties now, or later?
         if init_handlers:
@@ -121,25 +122,28 @@ class HasEventsJS:
                 'get': getter, 'set': setter}
         Object.defineProperty(self, name, opts)
     
-    def __create_Emitter(self, name):
-        emitter_func = self['_' + name + '_func']
-        window.emitter_func = emitter_func
-        def func(*args):
+    def __create_Emitter(self, emitter_func, name):
+        # Keep a ref to the emitter func, which is a class attribute. The object
+        # attribute with the same name will be overwritten with the property below.
+        # Because the class attribute is the underlying function, super() works.
+        def func(*args):  # this func should return None, so super() works correct
             ev = emitter_func.apply(self, args)
-            self.emit(name, ev)
+            if ev is not None:
+                self.emit(name, ev)
         def getter():
-            return func  # self._get_emitter(name)
+            return func
         def setter(x):
             raise AttributeError('Emitter %s is not settable' % name)
         opts = {'enumerable': True, 'configurable': True,  # i.e. overloadable
                 'get': getter, 'set': setter}
         Object.defineProperty(self, name, opts)
     
-    def __create_Handler(self, func, name, connection_strings):
+    def __create_Handler(self, handler_func, name, connection_strings):
+        # Keep ref to the handler function, see comment in create_Emitter().
         
         # Create function that becomes our "handler object"
         def handler(*events):
-            return func.apply(self, events)
+            return handler_func.apply(self, events)
         
         # Attach methods to the function object (this gets replaced)
         HANDLER_METHODS_HOOK  # noqa
@@ -216,7 +220,7 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
     for name, val in sorted(cls.__dict__.items()):
         name = name.replace('_JS__', '_%s__' % cls_name.split('.')[-1])  # fix mangling
         if isinstance(val, BaseEmitter):
-            funcname = name # '_' + name + '_func'
+            funcname = name
             if isinstance(val, Property):
                 properties.append(name)
             else:

--- a/flexx/event/tests/test_both.py
+++ b/flexx/event/tests/test_both.py
@@ -707,6 +707,15 @@ class InheritedPerson2(InheritedPerson1):
     @event.emitter
     def some_event(self, v):
         return super().some_event(v + 1)
+    
+    @event.emitter
+    def null_event(self):
+        return None
+    
+    @event.emitter
+    def non_null_event(self):
+        return {}
+
 
 @run_in_both(InheritedPerson2, "['ernie.-ernie.', 'ernie.-jane.', 'x2', 'y2', 8]")
 def test_inheritance(InheritedPerson2):
@@ -723,6 +732,27 @@ def test_inheritance(InheritedPerson2):
     handler = name.connect(handler, 'some_event')
     #
     name.some_event(7)
+    handler.handle_now()
+    
+    return name.r1
+
+@run_in_both(InheritedPerson2, "['non_null_event']")
+def test_emitter_return_val(InheritedPerson2):
+    # property behavior can be overloaded, and handlers can be overloaded.
+    # super can be used, and works for at least two levels
+    name = InheritedPerson2()
+    name.first_name = 'jane'
+    name._first_name_logger.handle_now()
+    
+    # Test emitter inheritance
+    def handler(*events):
+        for ev in events:
+            name.r1.append(ev.type)
+    handler = name.connect(handler, 'null_event', 'non_null_event')
+    
+    name.r1.clear()
+    name.null_event()
+    name.non_null_event()
     handler.handle_now()
     
     return name.r1

--- a/flexx/event/tests/test_both.py
+++ b/flexx/event/tests/test_both.py
@@ -750,7 +750,7 @@ def test_emitter_return_val(InheritedPerson2):
             name.r1.append(ev.type)
     handler = name.connect(handler, 'null_event', 'non_null_event')
     
-    name.r1.clear()
+    name.r1 = []
     name.null_event()
     name.non_null_event()
     handler.handle_now()


### PR DESCRIPTION
Fixes #175 

This also makes some changes to the name of the underlying function for properties, emitters. Essentially, the underlying function needed to be stored under the actual name of the emitter for super() to work, and we made it work the same way for properties for consistency.