### PR TITLE
Improvements to app.serve(), app.launch(), app.export()

### DIFF
--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -36,8 +36,6 @@ INDEX = """<!doctype html>
     <meta charset="utf-8">
     <title>Flexx UI</title>
 
-ASSET-ID-HOOK
-
 ASSET-LINK-HOOK
 
 </head>
@@ -296,7 +294,6 @@ class SessionAssets:
         self._known_classes = set()  # Cache what classes we know (for performance)
         self._extra_model_classes = []  # Model classes that are not in an asset/module
         self._id = get_random_string()
-        self._app_name = 'FlexxApp'  # Set in Session class
     
     @property
     def id(self):
@@ -564,22 +561,19 @@ class SessionAssets:
         link_assets = []
         content_assets = []
         
-        # Set id  and classname asset
-        # todo: for export, the id does not matter
-        id_asset = '    <script>var flexx = {app_name: "%s", session_id: "%s"};</script>'
-        id_asset = id_asset % (self._app_name, self.id)
-        
         # Collect JS and CSS
         for fname, code in self._get_js_and_css_assets(True).items():
             if not code.strip():  # pragma: no cover
                 continue
-            if single or fname.startswith('index-'):
+            elif single or fname.startswith('index-'):
                 if fname.endswith('.css'):
                     t = "<style>\n/* CSS for %s */\n%s\n</style>"
                     content_assets.append(t % (fname, code))
                 else:
                     t = "<script>\n/* JS for %s */\n%s\n</script>"
                     content_assets.append(t % (fname, code))
+            elif fname.startswith('session') and fname.endswith('.js'):
+                link_assets.append("    <script>%s</script>" % code)
             else:
                 if fname.endswith('.css'):
                     t = "    <link rel='stylesheet' type='text/css' href='%s' />"
@@ -600,7 +594,6 @@ class SessionAssets:
         
         # Compose index page
         src = INDEX
-        src = src.replace('ASSET-ID-HOOK', id_asset)
         src = src.replace('ASSET-LINK-HOOK', '\n'.join(link_assets))
         src = src.replace('ASSET-CONTENT-HOOK', '\n'.join(content_assets))
         

--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -36,6 +36,8 @@ INDEX = """<!doctype html>
     <meta charset="utf-8">
     <title>Flexx UI</title>
 
+ASSET-ID-HOOK
+
 ASSET-LINK-HOOK
 
 </head>
@@ -294,6 +296,7 @@ class SessionAssets:
         self._known_classes = set()  # Cache what classes we know (for performance)
         self._extra_model_classes = []  # Model classes that are not in an asset/module
         self._id = get_random_string()
+        self._app_name = 'FlexxApp'  # Set in Session class
     
     @property
     def id(self):
@@ -561,6 +564,11 @@ class SessionAssets:
         link_assets = []
         content_assets = []
         
+        # Set id  and classname asset
+        # todo: for export, the id does not matter
+        id_asset = '    <script>var flexx = {app_name: "%s", session_id: "%s"};</script>'
+        id_asset = id_asset % (self._app_name, self.id)
+        
         # Collect JS and CSS
         for fname, code in self._get_js_and_css_assets(True).items():
             if not code.strip():  # pragma: no cover
@@ -592,6 +600,7 @@ class SessionAssets:
         
         # Compose index page
         src = INDEX
+        src = src.replace('ASSET-ID-HOOK', id_asset)
         src = src.replace('ASSET-LINK-HOOK', '\n'.join(link_assets))
         src = src.replace('ASSET-CONTENT-HOOK', '\n'.join(content_assets))
         

--- a/flexx/app/clientcore.py
+++ b/flexx/app/clientcore.py
@@ -4,7 +4,7 @@ The client's core Flexx engine, implemented in PyScript.
 
 from ..pyscript import py2js, undefined, window
 
-location = require = module = typeof = None  # fool PyFlakes
+flexx = location = require = module = typeof = None  # fool PyFlakes
 
 
 @py2js(inline_stdlib=False)

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -292,7 +292,7 @@ def init_notebook():
     display(HTML(t))
 
 
-def serve(cls):
+def serve(cls, path=None, properties=None):
     """ Serve the given Model class as a web app. Can be used as a decorator.
     
     This registers the given class with the internal app manager. The
@@ -300,23 +300,29 @@ def serve(cls):
     
     Arguments:
         cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
+        path (str): the relative path to serve the app on.
+        properties (dict, optional): the initial properties for the model. The
+          model is instantiated using ``Cls(**properties)``.
     
     Returns:
         cls: The given class.
     """
+    # todo: doc how to make it serve on root
     # Note: this talks to the manager; it has nothing to do with the server
     assert isinstance(cls, type) and issubclass(cls, Model)
-    manager.register_app_class(cls)
+    manager.register_app_class(cls, properties or {})
     return cls
 
 
-def launch(cls, runtime=None, **runtime_kwargs):
+def launch(cls, runtime=None, properties=None, **runtime_kwargs):
     """ Launch the given Model class as a desktop app in the given runtime.
     
     Arguments:
         cls (type, str): a subclass of ``app.Model`` (or ``ui.Widget`). If this 
             is a string, it simply calls ``webruntime.launch()``.
         runtime (str): the runtime to launch the application in. Default 'xul'.
+        properties (dict, optional): the initial properties for the model. The
+          model is instantiated using ``Cls(**properties)``.
         runtime_kwargs: kwargs to pass to the ``webruntime.launch`` function.
     
     Returns:
@@ -328,7 +334,7 @@ def launch(cls, runtime=None, **runtime_kwargs):
         raise ValueError('runtime must be a string or Model subclass.')
     
     # Create session
-    serve(cls)
+    serve(cls, None, properties)
     session = manager.create_session(cls.__name__)
     
     # Launch web runtime, the server will wait for the connection
@@ -345,13 +351,15 @@ def launch(cls, runtime=None, **runtime_kwargs):
     return session.app
 
 
-def export(cls, filename=None, single=True):
+def export(cls, filename=None, properties=None, single=True):
     """ Export the given Model class to an HTML document.
     
     Arguments:
         cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
         filename (str, optional): Path to write the HTML document to.
             If not given or None, will return the html as a string.
+        properties (dict, optional): the initial properties for the model. The
+          model is instantiated using ``Cls(**properties)``.
         single (bool): If True, will include all JS and CSS dependencies
             in the HTML page. If False, you want to export all assets
             using ``app.assets.export(dirname)``.
@@ -364,7 +372,7 @@ def export(cls, filename=None, single=True):
         raise ValueError('runtime must be a string or Model subclass.')
     
     # Create session
-    serve(cls)
+    serve(cls, None, properties)
     session = manager.create_session(cls.__name__)
     
     # Make fake connection using exporter object

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -292,7 +292,7 @@ def init_notebook():
     display(HTML(t))
 
 
-def serve(cls, path=None, properties=None):
+def serve(cls, name=None, properties=None):
     """ Serve the given Model class as a web app. Can be used as a decorator.
     
     This registers the given class with the internal app manager. The
@@ -300,7 +300,7 @@ def serve(cls, path=None, properties=None):
     
     Arguments:
         cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
-        path (str): the relative path to serve the app on.
+        name (str): the relative URL path to serve the app on.
         properties (dict, optional): the initial properties for the model. The
           model is instantiated using ``Cls(**properties)``.
     
@@ -310,7 +310,7 @@ def serve(cls, path=None, properties=None):
     # todo: doc how to make it serve on root
     # Note: this talks to the manager; it has nothing to do with the server
     assert isinstance(cls, type) and issubclass(cls, Model)
-    manager.register_app_class(cls, properties or {})
+    manager.register_app_class(cls, name, properties or {})
     return cls
 
 
@@ -334,8 +334,9 @@ def launch(cls, runtime=None, properties=None, **runtime_kwargs):
         raise ValueError('runtime must be a string or Model subclass.')
     
     # Create session
-    serve(cls, None, properties)
-    session = manager.create_session(cls.__name__)
+    name = cls.__name__
+    serve(cls, name, properties)
+    session = manager.create_session(name)
     
     # Launch web runtime, the server will wait for the connection
     server = current_server()
@@ -372,8 +373,9 @@ def export(cls, filename=None, properties=None, single=True):
         raise ValueError('runtime must be a string or Model subclass.')
     
     # Create session
-    serve(cls, None, properties)
-    session = manager.create_session(cls.__name__)
+    name = cls.__name__
+    serve(cls, name, properties)
+    session = manager.create_session(name)
     
     # Make fake connection using exporter object
     exporter = ExporterWebSocketDummy()

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -300,14 +300,14 @@ def serve(cls, name=None, properties=None):
     
     Arguments:
         cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
-        name (str): the relative URL path to serve the app on.
+        name (str): the relative URL path to serve the app on. If this is
+          ``''`` or ``'__main__'``, this will be the main app.
         properties (dict, optional): the initial properties for the model. The
           model is instantiated using ``Cls(**properties)``.
     
     Returns:
         cls: The given class.
     """
-    # todo: doc how to make it serve on root
     # Note: this talks to the manager; it has nothing to do with the server
     assert isinstance(cls, type) and issubclass(cls, Model)
     manager.register_app_class(cls, name, properties or {})

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -301,7 +301,7 @@ def serve(cls, name=None, properties=None):
     Arguments:
         cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
         name (str): the relative URL path to serve the app on. If this is
-          ``''`` or ``'__main__'``, this will be the main app.
+          ``''`` (the empty string), this will be the main app.
         properties (dict, optional): the initial properties for the model. The
           model is instantiated using ``Cls(**properties)``.
     

--- a/flexx/app/session.py
+++ b/flexx/app/session.py
@@ -125,7 +125,7 @@ class AppManager(event.HasEvents):
         
         # Session and app class need each-other, thus the _set_app()
         session = Session(name)
-        app = cls(session=session, is_app=True, **properties)  # is_app marks this Model as "main"
+        app = cls(session=session, is_app=True, **properties)  # is_app marks it as main
         session._set_app(app)
         
         # Now wait for the client to connect. The client will be served
@@ -232,7 +232,9 @@ class Session(SessionAssets):
     def __init__(self, app_name):
         super().__init__()
         
-        # Init assets
+        # Init assets (need that \n to make it look like code on py2
+        t = 'var flexx = {app_name: "%s", session_id: "%s"};\n' % (app_name, self.id)
+        self.add_asset('session-id.js', t.encode())
         self.use_global_asset('pyscript-std.js')
         self.use_global_asset('flexx-app.js')
         

--- a/flexx/app/session.py
+++ b/flexx/app/session.py
@@ -32,7 +32,7 @@ class AppManager(event.HasEvents):
         self._appinfo = {}
         self._last_check_time = time.time()
     
-    def register_app_class(self, cls, properties):
+    def register_app_class(self, cls, name, properties):
         """ Register a Model class as being an application.
         
         After registering a class, it becomes possible to connect to 
@@ -40,11 +40,13 @@ class AppManager(event.HasEvents):
         
         Parameters:
           cls (Model): The Model class to serv as an app.
+          name (str): The name (relative url path) by which this app can be accessed.
           properties (dict): The model's initial properties.
         """
+        name = cls.__name__ if name is None else name
         assert isinstance(cls, type) and issubclass(cls, Model)
+        assert isinstance(name, str)
         assert isinstance(properties, dict)
-        name = cls.__name__
         if not valid_app_name(name):
             raise ValueError('Given app does not have a valid name %r' % name)
         pending, connected = [], []
@@ -121,7 +123,7 @@ class AppManager(event.HasEvents):
         cls, properties, pending, connected = self._appinfo[name]
         
         # Session and app class need each-other, thus the _set_app()
-        session = Session(cls.__name__)
+        session = Session(name)
         app = cls(session=session, is_app=True, **properties)  # is_app marks this Model as "main"
         session._set_app(app)
         

--- a/flexx/app/session.py
+++ b/flexx/app/session.py
@@ -28,39 +28,41 @@ class AppManager(event.HasEvents):
     
     def __init__(self):
         super().__init__()
-        # name -> (ModelClass, pending, connected) - lists contain proxies
-        self._proxies = {}
+        # name -> (ModelClass, properties, pending, connected) - lists contain Sessions
+        self._appinfo = {}
         self._last_check_time = time.time()
     
-    def register_app_class(self, cls):
+    def register_app_class(self, cls, properties):
         """ Register a Model class as being an application.
         
-        Applications are identified by the ``__name__`` attribute of
-        the class. The given class must inherit from ``Model``.
-        
         After registering a class, it becomes possible to connect to 
-        "http://address:port/ClassName". 
+        "http://address:port/ClassName".
+        
+        Parameters:
+          cls (Model): The Model class to serv as an app.
+          properties (dict): The model's initial properties.
         """
         assert isinstance(cls, type) and issubclass(cls, Model)
+        assert isinstance(properties, dict)
         name = cls.__name__
         if not valid_app_name(name):
             raise ValueError('Given app does not have a valid name %r' % name)
         pending, connected = [], []
-        if name in self._proxies and cls is not self._proxies[name][0]:
-            oldCls, pending, connected = self._proxies[name]
+        if name in self._appinfo and cls is not self._appinfo[name][0]:
+            oldCls, pending, connected = self._appinfo[name]
             logger.warn('Re-registering app class %r' % name)
             #raise ValueError('App with name %r already registered' % name)
-        self._proxies[name] = cls, pending, connected
+        self._appinfo[name] = cls, properties, pending, connected
     
     def create_default_session(self):
         """ Create a default session for interactive use (e.g. the notebook).
         """
         
-        if '__default__' in self._proxies:
+        if '__default__' in self._appinfo:
             raise RuntimeError('The default session can only be created once.')
         
         session = Session('__default__')
-        self._proxies['__default__'] = (None, [session], [])
+        self._appinfo['__default__'] = (None, {}, [session], [])
         return session
     
     def get_default_session(self):
@@ -70,22 +72,22 @@ class AppManager(event.HasEvents):
         When a Model class is created without a session, this method
         is called to get one (and will then fail if it's None).
         """
-        x = self._proxies.get('__default__', None)
+        x = self._appinfo.get('__default__', None)
         if x is None:
             return None
         else:
-            _, pending, connected = x
-            proxies = pending + connected
-            return proxies[-1]
+            _, _, pending, connected = x
+            sessions = pending + connected
+            return sessions[-1]
     
     def _clear_old_pending_sessions(self):
         try:
             
             count = 0
-            for name in self._proxies:
+            for name in self._appinfo:
                 if name == '__default__':
                     continue
-                _, pending, _ = self._proxies[name]
+                _, _, pending, _ = self._appinfo[name]
                 to_remove = [s for s in pending
                              if (time.time() - s._creation_time) > 10]
                 for s in to_remove:
@@ -113,14 +115,14 @@ class AppManager(event.HasEvents):
         
         if name == '__default__':
             raise RuntimeError('There can be only one __default__ session.')
-        elif name not in self._proxies:
+        elif name not in self._appinfo:
             raise ValueError('Can only instantiate a session with a valid app name.')
         
-        cls, pending, connected = self._proxies[name]
+        cls, properties, pending, connected = self._appinfo[name]
         
         # Session and app class need each-other, thus the _set_app()
         session = Session(cls.__name__)
-        app = cls(session=session, is_app=True)  # is_app marks this Model as "main"
+        app = cls(session=session, is_app=True, **properties)  # is_app marks this Model as "main"
         session._set_app(app)
         
         # Now wait for the client to connect. The client will be served
@@ -134,7 +136,7 @@ class AppManager(event.HasEvents):
     def connect_client(self, ws, name, app_id):
         """ Connect a client to a session that was previously created.
         """
-        cls, pending, connected = self._proxies[name]
+        _, _, pending, connected = self._appinfo[name]
         
         # Search for the session with the specific id
         for session in pending:
@@ -160,7 +162,7 @@ class AppManager(event.HasEvents):
         The manager will remove the session from the list of connected
         instances.
         """
-        cls, pending, connected = self._proxies[session.app_name]
+        _, _, pending, connected = self._appinfo[session.app_name]
         try:
             connected.remove(session)
         except ValueError:
@@ -172,18 +174,18 @@ class AppManager(event.HasEvents):
     def has_app_name(self, name):
         """ Returns True if name is a registered appliciation name
         """
-        return name in self._proxies.keys()
+        return name in self._appinfo.keys()
     
     def get_app_names(self):
         """ Get a list of registered application names (excluding those
         that start with an underscore).
         """
-        return [name for name in self._proxies.keys() if not name.startswith('_')]
+        return [name for name in self._appinfo.keys() if not name.startswith('_')]
     
     def get_session_by_id(self, name, id):
         """ Get session object by name and id
         """
-        cls, pending, connected = self._proxies[name]
+        _, _, pending, connected = self._appinfo[name]
         for session in pending:
             if session.id == id:
                 return session
@@ -194,7 +196,7 @@ class AppManager(event.HasEvents):
     def get_connections(self, name):
         """ Given an app name, return the session connected objects.
         """
-        cls, pending, connected = self._proxies[name]
+        _, _, pending, connected = self._appinfo[name]
         return list(connected)
     
     @event.emitter

--- a/flexx/app/tests/test_funcs.py
+++ b/flexx/app/tests/test_funcs.py
@@ -15,6 +15,20 @@ def test_add_handlers():
     assert tornado_app.add_handlers
 
 
+def test_setting_properties():
+    
+    class MyPropClass(app.Model):
+        @event.prop
+        def foo(self, v=1):
+            return v
+    
+    m = app.launch(MyPropClass)
+    assert m.foo == 1
+    
+    m = app.launch(MyPropClass, None, dict(foo=3))
+    assert m.foo == 3
+
+    
 def test_restarting():
     """ Test stopping and starting the ioloop.
     """

--- a/flexx/app/tests/test_funcs.py
+++ b/flexx/app/tests/test_funcs.py
@@ -24,9 +24,11 @@ def test_setting_properties():
     
     m = app.launch(MyPropClass)
     assert m.foo == 1
+    m.session.close()
     
     m = app.launch(MyPropClass, None, dict(foo=3))
     assert m.foo == 3
+    m.session.close()
 
     
 def test_restarting():

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -254,9 +254,9 @@ class MainHandler(tornado.web.RequestHandler):
         
         # Redirect to fixed app name?
         correct_app_name = manager.has_app_name(app_name)
-        if correct_app_name and ((correct_app_name != app_name) or
-                                 (app_name in path and '/' not in path)):
-            self.redirect('/%s/' % correct_app_name)
+        if correct_app_name and app_name in path and ('/' not in path or
+                                                      correct_app_name != app_name):
+            self.redirect('/%s/%s' % (correct_app_name, file_name))
         
         if app_name == '__index__':
             # Show plain index page
@@ -339,8 +339,8 @@ class MainHandler(tornado.web.RequestHandler):
                 try:
                     res = assets.load_asset(file_name)
                 except (IOError, IndexError):
-                    self.write('Invalid resource %r' % file_name)
-                    # super().write_error(404)
+                    # self.write('Invalid resource %r' % file_name)
+                    super().write_error(404)
                 else:
                     self.write(res)
         


### PR DESCRIPTION
Closes #140 

* The functions `app.serve(), app.launch(), app.export()` all have a similar API where the first arg is the Model class, the second a place to "put" it, and the third a dict of initial properties.
* For `serve()`, the second arg is a path to serve it on, which can be set to the empty string to serve it as the "main" app.
* App names in the url are case insensitive. If the url does not match the proper case, the page is redirected to the correct case.
* Refactored `MainHandler.get()` a bit.
