### PR TITLE
Fix that handler could no longer connect to builtin functions

### DIFF
--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -158,9 +158,10 @@ class Handler:
         if isinstance(func, tuple):
             self._ob2 = weakref.ref(func[1])
             func = func[0]
-        if getattr(func, '__self__', None) is not None:
-            self._ob2 = weakref.ref(func.__self__)
-            func = func.__func__
+        if getattr(func, '__self__', None) is not None:  # builtin funcs have __self__
+            if getattr(func, '__func__', None) is not None:
+                self._ob2 = weakref.ref(func.__self__)
+                func = func.__func__
         
         # Store func, name, and docstring (e.g. for sphinx docs)
         assert callable(func)

--- a/flexx/event/tests/test_handlers.py
+++ b/flexx/event/tests/test_handlers.py
@@ -192,6 +192,15 @@ def test_func_handlers_with_method_decorator():
     assert repr(foo)
 
 
+def test_handler_builtin_function():
+    
+    class Foo(event.HasEvents):
+        pass
+    
+    foo = Foo()
+    foo.connect('!bar', print)  # this should not error
+
+
 def test_method_handler_invoking():
     called = []
     


### PR DESCRIPTION
E.g. `foo.connect('bar', print)` would not work anymore.