### PR TITLE
Warn if handler connects to event that is not known

### DIFF
--- a/flexx/event/__init__.py
+++ b/flexx/event/__init__.py
@@ -21,7 +21,7 @@ An event is something that has occurred at a certain moment in time,
 such as the mouse being pressed down or a property changing its value.
 In this framework events are represented with dictionary objects that
 provide information about the event (such as what button was pressed,
-or the new value of a property). A custom :class:`Dict <flexx.event.Dict>`
+or the old and new value of a property). A custom :class:`Dict <flexx.event.Dict>`
 class is used that inherits from ``dict`` but allows attribute access,
 e.g. ``ev.button`` as an alternative to ``ev['button']``.
 
@@ -35,7 +35,7 @@ class for objects that have properties and/or emit events. E.g. a
 from ``flexx.event.HasEvents``.
 
 Events are emitted using the :func:`emit() <flexx.event.HasEvents.emit>`
-method, which accepts a name for the type of the event, and a dict:
+method, which accepts a name for the type of the event, and optionally a dict,
 e.g. ``emitter.emit('mouse_down', dict(button=1, x=103, y=211))``.
 
 The HasEvents object will add two attributes to the event: ``source``,
@@ -43,7 +43,7 @@ a reference to the HasEvents object itself, and ``type``, a string
 indicating the type of the event.
 
 As a user, you generally do not need to emit events explicitly; events are
-automatically emitted e.g. when setting a property.
+automatically emitted, e.g. when setting a property.
 
 
 Handler
@@ -82,7 +82,14 @@ is up to the programmer to determine whether only one action is
 required, or whether all events need processing. In the latter case,
 just use ``for ev in events: ...``.
 
-Another useful feature of this system is that a handler can connect to
+In most cases, you will connect to events that are known beforehand,
+like those they correspond to properties, readonlies and emitters. 
+If you connect to an event that is not known (as in the example above)
+it might be a typo and Flexx will display a warning. Use `'!foo'` as a
+connection string (i.e. prepend an exclamation mark) to suppress such
+warnings.
+
+Another useful feature of the event system is that a handler can connect to
 multiple events at once:
 
 .. code-block:: python
@@ -249,7 +256,7 @@ is a ``HasEvents`` subclass that has properties ``parent`` and
     def parent_foo_handler(*events):
         ...
     
-    @main.connect('children.*.foo')
+    @main.connect('children*.foo')
     def children_foo_handler(*events):
         ...
 

--- a/flexx/event/examples/basic_emit.py
+++ b/flexx/event/examples/basic_emit.py
@@ -1,18 +1,20 @@
 """
 Example demonstrating the emitting of events using the emit() method.
-This also shows how a method prefixed with "on_" is automatically
-connected to the corresponding event.
+
+The "!" in the event name is to supress a warning for connecting to an
+event that is not known beforehand (i.e. there is no corresponding
+property or emitter).
 """
 
 from flexx import event
 
 class Basic(event.HasEvents):
     
-    @event.connect('foo')
+    @event.connect('!foo')
     def on_foo(self, *events):
         print('foo handler called with %i events' % len(events))
     
-    @event.connect('bar')
+    @event.connect('!bar')
     def on_bar(self, *events):
         print('bar handler called with %i events' % len(events))
 

--- a/flexx/ui/examples/chatroom.py
+++ b/flexx/ui/examples/chatroom.py
@@ -75,7 +75,7 @@ class ChatRoom(ui.Widget):
     
     class JS:
         
-        @event.connect('new_message')
+        @event.connect('!new_message')
         def _update_total_text(self, *events):
             self.messages.text += ''.join([ev.msg for ev in events])
 

--- a/flexx/ui/examples/colab_painting.py
+++ b/flexx/ui/examples/colab_painting.py
@@ -101,7 +101,7 @@ class ColabPainting(ui.Widget):
         def _update_color(self, *events):
             self.canvas.style = 'border: 10px solid ' + events[-1].new_value
         
-        @event.connect('paint')
+        @event.connect('!paint')
         def _paint_dot(self, *events):
             for ev in events:
                 self._ctx.globalAlpha = 0.8

--- a/flexx/ui/examples/monitor.py
+++ b/flexx/ui/examples/monitor.py
@@ -90,7 +90,7 @@ class Monitor(ui.Widget):
             import time
             self.start_time = time.time()
         
-        @event.connect('system_info')
+        @event.connect('!system_info')
         def _update_info(self, *events):
             ev = events[-1]
             


### PR DESCRIPTION
Fixes #188 

There are two options when an event is connected that is not known:
* warn (as we do now)
* error

I think a warning suffices and is more backward compatible.

To do:

* [x] Decide what syntax do we use to suppress the warning. It's now done by prepending the connection string with an exclamation mark (related to #194).
* [x] docs

cc @korijn