### PR TITLE
Support for Windows HTA

### DIFF
--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -368,6 +368,10 @@ def export(cls, filename=None, properties=None, single=True):
     Returns:
         html (str): The resulting html. If a filename was specified
         this returns None.
+    
+    Notes:
+        If the given filename ends with .hta, a Windows HTML Application is
+        created.
     """
     if not (isinstance(cls, type) and issubclass(cls, Model)):
         raise ValueError('runtime must be a string or Model subclass.')
@@ -388,6 +392,9 @@ def export(cls, filename=None, properties=None, single=True):
     html = session.get_page_for_export(exporter._commands, single)
     if filename is None:
         return html
+    elif filename.lower().endswith('.hta'):
+        hta_tag = '<meta http-equiv="x-ua-compatible" content="ie=edge" />'
+        html = html.replace('<head>', '<head>\n    ' + hta_tag, 1)
     
     # Save to file
     if filename.startswith('~'):

--- a/flexx/ui/widgets/_group.py
+++ b/flexx/ui/widgets/_group.py
@@ -64,6 +64,12 @@ class GroupWidget(Widget):
             
             self.node = self.phosphor.node
         
+        @event.connect('children')
+        def _keep_legend_up(self, *events):
+            if len(self.children):
+                first = self.children[0].outernode
+                self.node.insertBefore(self._legend, first)
+        
         @event.connect('title')
         def _title_changed(self, *events):
             self._legend.innerHTML = self.title

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -71,8 +71,7 @@ class Slider(Widget):
             self.node.type = 'range'
             f = lambda ev: self._set_prop('user_value', self.node.value)
             self.node.addEventListener('input', f, False)
-            #if IE10:
-            #   this.node.addEventListener('change', f, False)
+            this.node.addEventListener('change', f, False)  # IE
         
         @event.readonly
         def user_value(self, v=None):

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -71,7 +71,7 @@ class Slider(Widget):
             self.node.type = 'range'
             f = lambda ev: self._set_prop('user_value', self.node.value)
             self.node.addEventListener('input', f, False)
-            this.node.addEventListener('change', f, False)  # IE
+            self.node.addEventListener('change', f, False)  # IE
         
         @event.readonly
         def user_value(self, v=None):


### PR DESCRIPTION
HTA is a format that is really just an .html file renamded to .hta, and one tag added. It's a bit of an old thing, and Edget does not support it. But its easy to add.

I was investigating this as a way to create native-looking desktop apps on Windows. Probably can work, but would not be a modern solution. But if we get a modern solution (e.g. based on UWP), we still might need HTA for older machines.

* [x] Make work as an export mechanism
* [ ] Make work as a runtime
* [ ] Should export logic not be part of the runtime? E.g. maybe we'll someday get export to NWJS, etc. that seems more runtime related.

*Leaving these open, since HTA should only become a backend for `launch` if we have one that runs on Edge.` The question of which module should take care of exports is still a valid one, but we can address that when we add more export modes.*