### PR TITLE
Prevent default event actions only for canvas

### DIFF
--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -482,15 +482,6 @@ class Widget(Model):
             self.node.addEventListener('keyup', self.key_up, 0)
             self.node.addEventListener('keypress', self.key_press, 0)
             
-            # Disable context menu so we can handle RMB clicks
-            # Firefox is particularly stuborn with Shift+RMB, and RMB dbl click
-            if not window.flexx._disabled_context_menu:
-                self._disabled_context_menu = True
-                _context_menu = lambda ev: ev.preventDefault() and False
-                window.document.addEventListener('contextmenu', _context_menu, 0)
-                window.document.addEventListener('click', _context_menu, 0)
-                #window.document.addEventListener('dblclick', _context_menu, 0)
-            
             # Implement mouse capturing. When a mouse is pressed down on
             # a widget, it "captures" the mouse, and will continue to receive
             # move and up events, even if the mouse is not over the widget.


### PR DESCRIPTION
Closes #174 

Based on the observation that preventing context menu etc. is mainly a concern for apps that make use of the canvas for user interaction, I've moved the preventdefault-logic to the canvas.

In theory someone could want extensive user interaction with html elements. in that case he/she can look at how its handled in the `Canvas` and apply that approach.

For now I've left open a way to invoke the context menu by holding down all 3 modifier keys. Let's see how that works out.

I did a bit of work on making capturing wheel events work in a nice way. I.e. allow the canvas to prevent page scrolling but not when the canvas just happens to "pass by"  during scrolling. I.e. for interactive apps in the notebook. Such apps should set the class attribute `CAPTURE_WHEEL` of the `Canvas` subclass to `True`. Its not tested that well, but it's probably a good start, anyway.