### PR TITLE
Fix for boxpanel in vbox on chrome

### DIFF
--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -105,6 +105,11 @@ class Widget(Model):
        width: 100%;
        height: 100%;
     }
+    
+    /* to position children absolute */
+    .flx-abs-children > .flx-Widget {
+        position: absolute;
+    }
     """
 
     def __init__(self, **kwargs):
@@ -703,6 +708,7 @@ class Widget(Model):
             if 'flx-Layout' not in self.outernode.className:
                 self.outernode.classList.remove('flx-hbox')
                 self.outernode.classList.remove('flx-vbox')
+                self.outernode.classList.remove('flx-abs-children')
                 children = self.children
                 if len(children) == 1:
                     subClassName = children[0].outernode.className
@@ -710,3 +716,5 @@ class Widget(Model):
                         self.outernode.classList.add('flx-hbox')
                     elif 'flx-HBox' in subClassName:
                         self.outernode.classList.add('flx-vbox')
+                    elif 'flx-BoxPanel' in subClassName:
+                        self.outernode.classList.add('flx-abs-children')

--- a/flexx/ui/examples/deep.py
+++ b/flexx/ui/examples/deep.py
@@ -120,5 +120,5 @@ class Deep(ui.Widget):
 
 
 if __name__ == '__main__':
-    app.launch(Deep)
+    app.launch(Deep, 'chromeapp')
     app.run()

--- a/flexx/ui/examples/deep2.py
+++ b/flexx/ui/examples/deep2.py
@@ -1,0 +1,34 @@
+"""
+Example to mix BoxPanel and VBox, which at some point failed in Chrome. Now
+Flexx takes precautions to make it work. This example is to test that it
+still works.
+"""
+
+from flexx import app, event, ui
+
+
+class Red(ui.Widget):
+    CSS = '.flx-Red { background: #ff0000;}'
+
+
+class Deep2(ui.Widget):
+    
+    def init(self):
+        
+        with ui.VBox():
+            
+            ui.Label(text='Widgets in BoxPanels in a widget in a vbox')
+        
+            with ui.Widget(flex=1):
+                with ui.BoxPanel(orientation='v'):
+                    with ui.BoxPanel(orientation='h'):
+                        Red(flex=1)
+                        Red(flex=1)
+                    with ui.BoxPanel(orientation='h'):
+                        Red(flex=1)
+                        Red(flex=1)
+
+
+if __name__ == '__main__':
+    m = app.launch(Deep2, 'chromeapp')
+    app.run()

--- a/flexx/ui/examples/deep2.py
+++ b/flexx/ui/examples/deep2.py
@@ -4,7 +4,7 @@ Flexx takes precautions to make it work. This example is to test that it
 still works.
 """
 
-from flexx import app, event, ui
+from flexx import app, ui
 
 
 class Red(ui.Widget):


### PR DESCRIPTION
This bug has been in Flexx for a long time but only surfaced recently. Flexx already has a fix for a similar situation with a VBox in a VBox, but in this case it was a BoxPanel in a VBox.

cc @korijn

Needs a test/example.