### PR TITLE
Widget.css_class_name

### DIFF
--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -178,8 +178,8 @@ class Widget(Model):
             return str(v)
         
         @event.prop
-        def css_class_name(self, v=''):
-            """ The extra CSS class names to asign to the DOM element.
+        def css_class(self, v=''):
+            """ The extra CSS class name to asign to the DOM element.
             Spaces can be used to delimit multiple names. Note that the
             DOM element already has a css class-name corresponding to
             its class (e.g. 'flx-Widget) and all its superclasses.
@@ -194,7 +194,7 @@ class Widget(Model):
             Note that setting this propery is cumulative; setting it back
             to the empty string does not undo previously set styling.
             A better approach might be to add CSS to the CSS class attribute
-            and use ``css_class_name``.
+            and use ``css_class``.
             """
             if isinstance(v, dict):
                 v = ['%s: %s' % (k, v) for k, v in v.items()]
@@ -383,8 +383,8 @@ class Widget(Model):
                     parent.phosphor.fit()  # i.e. p.processMessage(p.MsgFitRequest)
                 self.phosphor.update()
         
-        @event.connect('css_class_name')
-        def __css_class_name_changed(self, *events):
+        @event.connect('css_class')
+        def __css_class_changed(self, *events):
             if len(events):
                 # Reset / apply explicitly given class name (via the prop)
                 for cn in events[0].old_value.split(' '):

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -176,14 +176,25 @@ class Widget(Model):
             in e.g. a tab layout or form layout.
             """
             return str(v)
-    
+        
+        @event.prop
+        def css_class_name(self, v=''):
+            """ The extra CSS class names to asign to the DOM element.
+            Spaces can be used to delimit multiple names. Note that the
+            DOM element already has a css class-name corresponding to
+            its class (e.g. 'flx-Widget) and all its superclasses.
+            """
+            return str(v)
+        
         @event.prop
         def style(self, v=''):
             """ CSS style options for this widget object. e.g.
             ``"background: #f00; color: #0f0;"``. If the given value is a
             dict, its key-value pairs are converted to a CSS style string.
-            Note that the CSS class attribute can be used to style all
-            instances of a class.
+            Note that setting this propery is cumulative; setting it back
+            to the empty string does not undo previously set styling.
+            A better approach might be to add CSS to the CSS class attribute
+            and use ``css_class_name``.
             """
             if isinstance(v, dict):
                 v = ['%s: %s' % (k, v) for k, v in v.items()]
@@ -304,8 +315,8 @@ class Widget(Model):
                 self.title = title.label
             self.phosphor.title.changed.connect(_title_changed_in_phosphor)
             
-            # Derive css class name
-            cls_name = self._class_name
+            # Derive css class name from class hierarchy
+            cls_name = self._class_name  # _class_name is a PyScript thing
             for i in range(32):  # i.e. a safe while-loop
                 self.outernode.classList.add('flx-' + cls_name)
                 cls = window.flexx.classes[cls_name]
@@ -316,7 +327,7 @@ class Widget(Model):
                     break
             else:
                 raise RuntimeError('Error determining class names for %s' % self.id)
-
+        
         def _init_phosphor_and_node(self):
             """ Overload this in sub widgets.
             """
@@ -371,7 +382,18 @@ class Widget(Model):
                 if parent:
                     parent.phosphor.fit()  # i.e. p.processMessage(p.MsgFitRequest)
                 self.phosphor.update()
-
+        
+        @event.connect('css_class_name')
+        def __css_class_name_changed(self, *events):
+            if len(events):
+                # Reset / apply explicitly given class name (via the prop)
+                for cn in events[0].old_value.split(' '):
+                    if cn:
+                        self.outernode.classList.remove(cn)
+                for cn in events[-1].new_value.split(' '):
+                    if cn:
+                        self.outernode.classList.add(cn)
+        
         @event.connect('title')
         def __title_changed(self, *events):
             # All Phosphor widgets have a title

--- a/flexx/ui/examples/mondriaan.py
+++ b/flexx/ui/examples/mondriaan.py
@@ -8,6 +8,7 @@ from flexx import app, ui
 
 
 class MyVBox(ui.BoxLayout):
+    
     def __init__(self, **kwargs):
         kwargs['spacing'] = kwargs.get('spacing', 15)
         kwargs['padding'] = 0
@@ -25,6 +26,11 @@ class Mondriaan(ui.Widget):
     
     CSS = """
     .flx-Mondriaan {background: #000;}
+    .flx-Mondriaan .edge {background:none;}
+    .flx-Mondriaan .white {background:#fff;}
+    .flx-Mondriaan .red {background:#f23;}
+    .flx-Mondriaan .blue {background:#249;}
+    .flx-Mondriaan .yellow {background:#ff7;}
     """
     
     def init(self):
@@ -33,25 +39,25 @@ class Mondriaan(ui.Widget):
             with MyVBox(flex=2):
                 
                 with MyVBox(flex=4, spacing=30):
-                    ui.Widget(flex=1, style='background:#fff;')
-                    ui.Widget(flex=1, style='background:#fff;')
+                    ui.Widget(flex=1, css_class_name='white')
+                    ui.Widget(flex=1, css_class_name='white')
                 
-                with MyVBox(flex=2, style='background:#249;'):
-                    ui.Widget(flex=1, style='background:none;')
-                    ui.Widget(flex=1, style='background:none;')
+                with MyVBox(flex=2, css_class_name='blue'):
+                    ui.Widget(flex=1, css_class_name='edge')
+                    ui.Widget(flex=1, css_class_name='edge')
                 
             with MyVBox(flex=6):
                 
-                with MyVBox(flex=4, spacing=30, style='background:#f23;'):
-                    ui.Widget(flex=1, style='background:none;')
-                    ui.Widget(flex=1, style='background:none;')
+                with MyVBox(flex=4, spacing=30, css_class_name='red'):
+                    ui.Widget(flex=1, css_class_name='edge')
+                    ui.Widget(flex=1, css_class_name='edge')
                 
                 with MyHBox(flex=2):
-                    ui.Widget(flex=6, style='background:#fff;')
+                    ui.Widget(flex=6, css_class_name='white')
                     
                     with MyVBox(flex=1):
-                        ui.Widget(flex=1, style='background:#fff;')
-                        ui.Widget(flex=1, style='background:#ff7;')
+                        ui.Widget(flex=1, css_class_name='white')
+                        ui.Widget(flex=1, css_class_name='yellow')
 
 
 if __name__ == '__main__':

--- a/flexx/ui/examples/mondriaan.py
+++ b/flexx/ui/examples/mondriaan.py
@@ -39,25 +39,25 @@ class Mondriaan(ui.Widget):
             with MyVBox(flex=2):
                 
                 with MyVBox(flex=4, spacing=30):
-                    ui.Widget(flex=1, css_class_name='white')
-                    ui.Widget(flex=1, css_class_name='white')
+                    ui.Widget(flex=1, css_class='white')
+                    ui.Widget(flex=1, css_class='white')
                 
-                with MyVBox(flex=2, css_class_name='blue'):
-                    ui.Widget(flex=1, css_class_name='edge')
-                    ui.Widget(flex=1, css_class_name='edge')
+                with MyVBox(flex=2, css_class='blue'):
+                    ui.Widget(flex=1, css_class='edge')
+                    ui.Widget(flex=1, css_class='edge')
                 
             with MyVBox(flex=6):
                 
-                with MyVBox(flex=4, spacing=30, css_class_name='red'):
-                    ui.Widget(flex=1, css_class_name='edge')
-                    ui.Widget(flex=1, css_class_name='edge')
+                with MyVBox(flex=4, spacing=30, css_class='red'):
+                    ui.Widget(flex=1, css_class='edge')
+                    ui.Widget(flex=1, css_class='edge')
                 
                 with MyHBox(flex=2):
-                    ui.Widget(flex=6, css_class_name='white')
+                    ui.Widget(flex=6, css_class='white')
                     
                     with MyVBox(flex=1):
-                        ui.Widget(flex=1, css_class_name='white')
-                        ui.Widget(flex=1, css_class_name='yellow')
+                        ui.Widget(flex=1, css_class='white')
+                        ui.Widget(flex=1, css_class='yellow')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Implement #213 

The name "css_class_name" is a bit long, but I fear that "class_name" will confuse people. Maybe "css_name", or "style_name"? I'd also consider renaming "style" to sorta group these two props together.

