### PR TITLE
Model.init() can now have args

### DIFF
--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -331,7 +331,7 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
     # CSS for this class (no css in the base class)
     CSS = ""
     
-    def __init__(self, session=None, is_app=False, **kwargs):
+    def __init__(self, *init_args, session=None, is_app=False, **kwargs):
         
         # Param "is_app" is not used, but we "take" the argument so it
         # is not mistaken for a property value.
@@ -394,7 +394,7 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
         # subwidgets etc. This is done here, at the point where the
         # properties are initialized, but the handlers not yet.
         with self:
-            self.init()
+            self.init(*init_args)
         self._session._exec('flexx.instances.%s.init();' % self._id)
         
         # Initialize handlers for Python and for JS. Done after init()

--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -331,7 +331,12 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
     # CSS for this class (no css in the base class)
     CSS = ""
     
-    def __init__(self, *init_args, session=None, is_app=False, **kwargs):
+    def __init__(self, *init_args, **kwargs):
+        
+        # Pop args that we need from the kwargs (because legacy Python does
+        # not support keyword args after *args).
+        session = kwargs.pop('session', None)
+        is_app = kwargs.pop('is_app', None)
         
         # Param "is_app" is not used, but we "take" the argument so it
         # is not mistaken for a property value.

--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -336,10 +336,7 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
         # Pop args that we need from the kwargs (because legacy Python does
         # not support keyword args after *args).
         session = kwargs.pop('session', None)
-        is_app = kwargs.pop('is_app', None)
-        
-        # Param "is_app" is not used, but we "take" the argument so it
-        # is not mistaken for a property value.
+        kwargs.pop('is_app', None)  # not used here, but need to "take" it 
         
         # Set id and register this instance
         Model._counter += 1

--- a/flexx/app/tests/test_model.py
+++ b/flexx/app/tests/test_model.py
@@ -85,6 +85,13 @@ class Foo6(Foo1):
             return {}
 
 
+class Foo7(Model):
+    
+    def init(self, foo, bar=0):
+        self.foo = foo
+        self.bar = bar
+
+
 def test_pairing1():
     
     assert isinstance(Foo1.title, event._emitters.Property)
@@ -118,6 +125,31 @@ def test_overloading():
     
     assert Foo4.title is not Foo1.title
     assert Foo4.JS.red is not Foo2.JS.red
+
+
+def test_init_args():
+    
+    # This test needs a default session
+    session = app.manager.get_default_session()
+    if session is None:
+        app.manager.create_default_session()
+    
+    with raises(TypeError):
+        m = Model(2, 3)
+    
+    m = Foo7(2, 3)
+    assert m.foo == 2
+    assert m.bar == 3
+    
+    m = Foo7(2)
+    assert m.foo == 2
+    assert m.bar == 0
+    
+    with raises(TypeError):
+        m = Foo7()
+    
+    with raises(TypeError):
+        m = Foo7(2, 3, 4)
 
 
 def test_both():

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -102,7 +102,7 @@ class Widget(Model):
     }
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, *init_args, **kwargs):
 
         # Handle parent
         parent = kwargs.pop('parent', None)
@@ -121,7 +121,7 @@ class Widget(Model):
             kwargs['container'] = 'body'
 
         # Init - pass signal values via kwargs
-        Model.__init__(self, **kwargs)
+        Model.__init__(self, *init_args, **kwargs)
         
         # All widgets need phosphor
         self._session.use_global_asset('phosphor-all.js', before='flexx-ui.css')


### PR DESCRIPTION
Fixes #228. Relates to closed issue #140 and PR #199.

So you can do:
```py

class MyModel(app.Model):
    def init(foo, bar=3):
        ...

...
m = MyModel(7, 8, **properties_are_passed_as_kwargs_as_usual)
```