### PR TITLE
app.App class

### DIFF
--- a/docs/app/api.rst
+++ b/docs/app/api.rst
@@ -25,11 +25,7 @@ Functions related to the event loop
 Functions related to us Model classes as apps
 ---------------------------------------------
 
-.. autofunction:: flexx.app.serve
-
-.. autofunction:: flexx.app.launch
-
-.. autofunction:: flexx.app.export
+.. autofunction:: flexx.app.App
 
 .. autofunction:: flexx.app.get_instance_by_id
 

--- a/flexx/app/__init__.py
+++ b/flexx/app/__init__.py
@@ -221,5 +221,5 @@ from .session import manager, Session
 from .model import Model, get_active_model
 from .model import get_instance_by_id, get_model_classes
 from .funcs import create_server, current_server, run, start, stop, call_later
-from .funcs import init_interactive, init_notebook, serve, launch, export
+from .funcs import init_interactive, init_notebook, App, serve, launch, export
 from .assetstore import assets, Asset, Bundle, JSModule

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -324,7 +324,7 @@ class App:
         if not self._is_served:
             name = os.path.basename(filename).split('.')[0]
             name = name.replace('-', '_').replace(' ', '_')
-            serve(cls, name, properties)
+            self.serve(name)
         
         # Create session with id equal to the app name. This would not be strictly
         # necessary to make exports work, but it makes sure that exporting twice

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -214,7 +214,8 @@ class App:
         self._cls = cls
         self.args = args
         self.kwargs = kwargs
-        self._path = None
+        self._path = cls.__name__  # can be overloaded by serve()
+        self._is_served = False
     
     def __call__(self, *args, **kwargs):
         a = list(self.args) + list(args)
@@ -234,23 +235,137 @@ class App:
         return self._cls
     
     @property
-    def path(self):
-        """ The url path that this app is served at. Is None if the app
-        is not served yet.
+    def is_served(self):
+        """ Whether this app is already registered by the app manager.
+        """
+        return self._is_served
+    
+    @property
+    def name(self):
+        """ The name of the app, i.e. the url path that this app is served at.
         """
         return self._path
     
-    # todo: move implementation here and make app.serve() et al. call these.
+    def serve(self, name=None):
+        """ Start serving this app.
+        
+        This registers the given class with the internal app manager. The
+        app can be loaded via 'http://hostname:port/app_name'.
+        
+        Arguments:
+            name (str, optional): the relative URL path to serve the app on.
+                If this is ``''`` (the empty string), this will be the main app.
+        """
+        # Note: this talks to the manager; it has nothing to do with the server
+        if self._is_served:
+            raise RuntimeError('This app (%s) is already served.' %
+                               self.name or '__main__')
+        if name is not None:
+            self._path = name
+        manager.register_app(self)
     
-    def serve(self, *args, **kwargs):
-        serve(self, *args, **kwargs)
+    def launch(self, runtime=None, **runtime_kwargs):
+        """ Launch this app as a desktop app in the given runtime.
+        
+        Arguments:
+            runtime (str): the runtime to launch the application in. Default 'xul'.
+            runtime_kwargs: kwargs to pass to the ``webruntime.launch`` function.
+        
+        Returns:
+            app (Model): an instance of the given class.
+        """
+        # Create session
+        if not self._is_served:
+            self.serve()
+        session = manager.create_session(self.name)
+        
+        # Launch web runtime, the server will wait for the connection
+        server = current_server()
+        host, port = server.serving
+        if runtime == 'nodejs':
+            js_assets, _ = session.get_assets_in_order()
+            all_js = '\n\n'.join([asset.to_string() for asset in js_assets])
+            url = '%s:%i/%s/' % (host, port, session.app_name)
+            session._runtime = launch('http://' + url, runtime=runtime, code=all_js)
+        else:
+            url = '%s:%i/%s/?session_id=%s' % (host, port, session.app_name, session.id)
+            session._runtime = webruntime.launch('http://' + url,
+                                                 runtime=runtime,
+                                                 **runtime_kwargs)
+        return session.app
     
-    def launch(self, *args, **kwargs):
-        launch(self, *args, **kwargs)
-    
-    def export(self, *args, **kwargs):
-        export(self, *args, **kwargs)
-    
+    def export(self, filename=None, link=None, write_shared=True):
+        """ Export the given Model class to an HTML document.
+        
+        Arguments:
+            filename (str, optional): Path to write the HTML document to.
+                If not given or None, will return the html as a string.
+            link (int): whether to link assets or embed them:
+            
+                * 0: all assets are embedded.
+                * 1: normal assets are embedded, remote assets remain remote.
+                * 2: all assets are linked (as separate files).
+                * 3: (default) normal assets are linked, remote assets remain remote.
+            write_shared (bool): if True (default) will also write shared assets
+                when linking to assets. This can be set to False when
+                exporting multiple apps to the same location. The shared assets can
+                then be exported last using ``app.assets.export(dirname)``.
+        
+        Returns:
+            html (str): The resulting html. If a filename was specified
+            this returns None.
+        
+        Notes:
+            If the given filename ends with .hta, a Windows HTML Application is
+            created.
+        """
+        
+        # Prepare name, based on exported file name (instead of cls.__name__)
+        if not self._is_served:
+            name = os.path.basename(filename).split('.')[0]
+            name = name.replace('-', '_').replace(' ', '_')
+            serve(cls, name, properties)
+        
+        # Create session with id equal to the app name. This would not be strictly
+        # necessary to make exports work, but it makes sure that exporting twice
+        # generates the exact same thing (no randomly generated dir names).
+        session = manager.create_session(self.name, self.name)
+        
+        # Make fake connection using exporter object
+        exporter = ExporterWebSocketDummy()
+        manager.connect_client(exporter, session.app_name, session.id)
+        
+        # Clean up again - NO keep in memory to ensure two sessions dont get same id
+        # manager.disconnect_client(session)
+        
+        # Warn if this app has data and is meant to be run standalone
+        if (not link) and session.get_data_names():
+            logger.warn('Exporting a standalone app, but it has registered data.')
+        
+        # Get HTML - this may be good enough
+        html = session.get_page_for_export(exporter._commands, link)
+        if filename is None:
+            return html
+        elif filename.lower().endswith('.hta'):
+            hta_tag = '<meta http-equiv="x-ua-compatible" content="ie=edge" />'
+            html = html.replace('<head>', '<head>\n    ' + hta_tag, 1)
+        elif not filename.lower().endswith(('.html', 'htm')):
+            raise ValueError('Invalid extension for exporting to %r' %
+                            os.path.basename(filename))
+        
+        # Save to file. If standalone, all assets will be included in the main html
+        # file, if not, we need to export shared assets and session assets too.
+        filename = os.path.abspath(os.path.expanduser(filename))
+        if link:
+            if write_shared:
+                assets.export(os.path.dirname(filename))
+            session._export(os.path.dirname(filename))
+        with open(filename, 'wb') as f:
+            f.write(html.encode())
+        
+        app_type = 'standalone app' if link else 'app'
+        logger.info('Exported %s to %r' % (app_type, filename))
+
 
 class NoteBookHelper:
     """ Object that captures commands send to the websocket during the
@@ -388,100 +503,31 @@ def init_notebook():
     # the widget show up in the notebook output area.
 
 
+# todo: deprecate these
+
 def serve(cls, name=None, properties=None):
-    """ Serve the given Model class as a web app. Can be used as a decorator.
-    
-    This registers the given class with the internal app manager. The
-    app can be loaded via 'http://hostname:port/classname'.
-    
-    Arguments:
-        cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
-        name (str): the relative URL path to serve the app on. If this is
-          ``''`` (the empty string), this will be the main app.
-        properties (dict, optional): the initial properties for the model. The
-          model is instantiated using ``Cls(**properties)``.
-    
-    Returns:
-        cls: The given class.
+    """ Backwards compat.
     """
     # Note: this talks to the manager; it has nothing to do with the server
-    assert ((isinstance(cls, type) and issubclass(cls, Model)) or
-            (isinstance(cls, App) and issubclass(cls.cls, Model)))
-    manager.register_app_class(cls, name, properties or {})
+    assert (isinstance(cls, type) and issubclass(cls, Model))
+    a = App(cls, **(properties or {}))
+    a.serve(name)
     return cls
 
 
 def launch(cls, runtime=None, properties=None, **runtime_kwargs):
-    """ Launch the given Model class as a desktop app in the given runtime.
-    
-    Arguments:
-        cls (type, str): a subclass of ``app.Model`` (or ``ui.Widget`). If this 
-            is a string, it simply calls ``webruntime.launch()``.
-        runtime (str): the runtime to launch the application in. Default 'xul'.
-        properties (dict, optional): the initial properties for the model. The
-          model is instantiated using ``Cls(**properties)``.
-        runtime_kwargs: kwargs to pass to the ``webruntime.launch`` function.
-    
-    Returns:
-        app (Model): an instance of the given class.
+    """ Backwards compat.
     """
     if isinstance(cls, str):
         return webruntime.launch(cls, runtime, **runtime_kwargs)
-    if isinstance(cls, type) and issubclass(cls, Model):
-        pass
-    elif isinstance(cls, App) and issubclass(cls.cls, Model):
-        pass
-    else:
-        raise ValueError('runtime must be a string or Model subclass.')
-    
-    # Create session
-    name = cls.__name__
-    serve(cls, name, properties)
-    session = manager.create_session(name)
-    
-    # Launch web runtime, the server will wait for the connection
-    server = current_server()
-    host, port = server.serving
-    if runtime == 'nodejs':
-        js_assets, _ = session.get_assets_in_order()
-        all_js = '\n\n'.join([asset.to_string() for asset in js_assets])
-        url = '%s:%i/%s/' % (host, port, session.app_name)
-        session._runtime = launch('http://' + url, runtime=runtime, code=all_js)
-    else:
-        url = '%s:%i/%s/?session_id=%s' % (host, port, session.app_name, session.id)
-        session._runtime = launch('http://' + url, runtime=runtime, **runtime_kwargs)
-    
-    return session.app
+    assert (isinstance(cls, type) and issubclass(cls, Model))
+    a = App(cls, **(properties or {}))
+    return a.launch(runtime, **runtime_kwargs)
 
 
 def export(cls, filename=None, properties=None, single=None, link=None,
            write_shared=True):
-    """ Export the given Model class to an HTML document.
-    
-    Arguments:
-        cls (Model): a subclass of ``app.Model`` (or ``ui.Widget``).
-        filename (str, optional): Path to write the HTML document to.
-            If not given or None, will return the html as a string.
-        properties (dict, optional): the initial properties for the model. The
-          model is instantiated using ``Cls(**properties)``.
-        link (int): whether to link assets or embed them:
-        
-            * 0: all assets are embedded.
-            * 1: normal assets are embedded, remote assets remain remote.
-            * 2: all assets are linked (as separate files).
-            * 3: (default) normal assets are linked, remote assets remain remote.
-        write_shared (bool): if True (default) will also write shared assets
-            when linking to assets. This can be set to False when
-            exporting multiple apps to the same location. The shared assets can
-            then be exported last using ``app.assets.export(dirname)``.
-    
-    Returns:
-        html (str): The resulting html. If a filename was specified
-        this returns None.
-    
-    Notes:
-        If the given filename ends with .hta, a Windows HTML Application is
-        created.
+    """ Backward compat.
     """
     if not (isinstance(cls, type) and issubclass(cls, Model)):
         raise ValueError('runtime must be a string or Model subclass.')
@@ -494,51 +540,8 @@ def export(cls, filename=None, properties=None, single=None, link=None,
                 link = 3
     link = int(link or 0)
     
-    # Prepare name, based on exported file name (instead of cls.__name__)
-    name = os.path.basename(filename).split('.')[0]
-    name = name.replace('-', '_').replace(' ', '_')
-    
-    serve(cls, name, properties)
-    
-    # Create session with id equal to the app name. This would not be strictly
-    # necessary to make exports work, but it makes sure that exporting twice
-    # generates the exact same thing (no randomly generated dir names).
-    session = manager.create_session(name, name)  # 2nd arg sets session._id
-    
-    # Make fake connection using exporter object
-    exporter = ExporterWebSocketDummy()
-    manager.connect_client(exporter, session.app_name, session.id)
-    
-    # Clean up again - NO keep in memory to ensure two sessions dont get same id
-    # manager.disconnect_client(session)
-    
-    # Warn if this app has data and is meant to be run standalone
-    if (not link) and session.get_data_names():
-        logger.warn('Exporting a standalone app, but it has registered data.')
-    
-    # Get HTML - this may be good enough
-    html = session.get_page_for_export(exporter._commands, link)
-    if filename is None:
-        return html
-    elif filename.lower().endswith('.hta'):
-        hta_tag = '<meta http-equiv="x-ua-compatible" content="ie=edge" />'
-        html = html.replace('<head>', '<head>\n    ' + hta_tag, 1)
-    elif not filename.lower().endswith(('.html', 'htm')):
-        raise ValueError('Invalid extension for exporting to %r' %
-                         os.path.basename(filename))
-    
-    # Save to file. If standalone, all assets will be included in the main html
-    # file, if not, we need to export shared assets and session assets too.
-    filename = os.path.abspath(os.path.expanduser(filename))
-    if link:
-        if write_shared:
-            assets.export(os.path.dirname(filename))
-        session._export(os.path.dirname(filename))
-    with open(filename, 'wb') as f:
-        f.write(html.encode())
-    
-    app_type = 'standalone app' if link else 'app'
-    logger.info('Exported %s to %r' % (app_type, filename))
+    a = App(cls, **(properties or {}))
+    return a.export(filename, link=link, write_shared=write_shared)
 
 
 class ExporterWebSocketDummy:

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -241,6 +241,20 @@ class App:
         return self._is_served
     
     @property
+    def url(self):
+        """ The url to acces this app. This raises an error if serve() has not
+        been called yet or if Flexx' server is not yet running.
+        """
+        if not self._is_served:
+            raise RuntimeError('Cannot determine app url if app is not yet "served".')
+        elif not (_current_server and _current_server.serving):
+            raise RuntimeError('Cannot determine app url if the server is not '
+                               'yet running.')
+        else:
+            host, port = _current_server.serving
+            return 'http://%s:%i/%s' % (host, port, self.name)
+    
+    @property
     def name(self):
         """ The name of the app, i.e. the url path that this app is served at.
         """
@@ -263,6 +277,7 @@ class App:
         if name is not None:
             self._path = name
         manager.register_app(self)
+        self._is_served = True
     
     def launch(self, runtime=None, **runtime_kwargs):
         """ Launch this app as a desktop app in the given runtime.

--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -357,10 +357,11 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
     
     def __init__(self, *init_args, **kwargs):
         
-        # Pop args that we need from the kwargs (because legacy Python does
-        # not support keyword args after *args).
+        # Pop args that we need from the kwargs (because legacy Python does not
+        # support keyword args after *args). Param "is_app" is not used here,
+        # but we "take" the argument so it is not mistaken for a property value.
         session = kwargs.pop('session', None)
-        kwargs.pop('is_app', None)  # not used here, but need to "take" it 
+        kwargs.pop('is_app', None)
         
         # Set id and register this instance
         Model._counter += 1

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -395,6 +395,8 @@ class Widget(Model):
             # All Phosphor widgets have a title
             self.phosphor.title.label = events[-1].new_value
             # todo: title also supports caption, icon, closable, and more
+            if self.parent is None and self.container == 'body':
+                window.document.title = self.title or 'Flexx app'
         
         ## Size
 
@@ -475,6 +477,7 @@ class Widget(Model):
                                                            self._check_real_size()))
             if id == 'body':
                 self.outernode.classList.add('flx-main-widget')
+                window.document.title = self.title or 'Flexx app'
             elif id:
                 # Update style. If there is stuff like min-height set (which
                 # would be common in the notebook), we need to reapply style

--- a/flexx/ui/examples/chatroom.py
+++ b/flexx/ui/examples/chatroom.py
@@ -82,6 +82,7 @@ class ChatRoom(ui.Widget):
 
 
 if __name__ == '__main__':
-    app.serve(ChatRoom)
-    # m = app.launch(ChatRoom)  # for use during development
+    a = app.App(ChatRoom, title='Flexx chatroom demo')
+    a.serve()
+    # a.launch()  # for use during development
     app.start()

--- a/flexx/ui/examples/demo.py
+++ b/flexx/ui/examples/demo.py
@@ -21,5 +21,5 @@ class Demo(ui.Widget):
 
 
 if __name__ == '__main__':
-    m = app.launch(Demo, 'firefox')
+    m = app.App(Demo, title='Flexx demo').launch('firefox')
     app.run()


### PR DESCRIPTION
This PR continuous #236, awaiting the merge of ~~#225~~ #271 because it touches parts of the session manager that we need to change as well.

This add an `App` class, so that positional and keyword arguments can be provided for an app:

``` py
app.App(MyModel, 2, 3, text='bla').launch()
```

The `app.launch()` and friends (`serve`, `export`) continue to exist, but will take a `Model` class, wrap it in an `App`, and call its corresponding method.

It will (probably) also allow stuff like this, useful for e.g. testing:

``` py
my_app = app.App(MyModel, 2, 3, text='bla')
my_app.serve()
# ... move my_app somewhere
my_app.name
my_app.url  # though this would need the server to be running
```
