### PR TITLE
Settle on a syntax for connection strings

### DIFF
--- a/flexx/app/_model.py
+++ b/flexx/app/_model.py
@@ -532,7 +532,7 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
             self._session._exec(cmd)
     
     def _register_handler(self, *args):
-        event_type = args[0].split(':')[0].strip('!')
+        event_type = args[0].split(':')[0]
         if not self.get_event_handlers(event_type):
             self.call_js('_new_event_type_hook("%s")' % event_type)
         return super()._register_handler(*args)
@@ -639,7 +639,7 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
             window.flexx.instances[self._id] = 'disposed'
         
         def _register_handler(self, *args):
-            event_type = args[0].split(':')[0].strip('!')
+            event_type = args[0].split(':')[0]
             if not self.get_event_handlers(event_type):
                 self._new_event_type_hook(event_type)
             return super()._register_handler(*args)

--- a/flexx/event/__init__.py
+++ b/flexx/event/__init__.py
@@ -201,11 +201,6 @@ Connection string syntax
 
 The strings used to connect events follow a few simple syntax rules:
 
-* The string optionally has a label suffix separated by a colon. The
-  label itself may consist of any chars.
-* The string can have a "!" at the end to suppres warnings for
-  connections to unknown event types. If the string has a label,
-  the exclamation mark comes before it.
 * Connection strings consist of parts separated by dots, thus forming a path.
   If an element on the path is a property, the connection will automatically
   reset when that property changes (a.k.a. dynamism, more on this below).
@@ -214,9 +209,16 @@ The strings used to connect events follow a few simple syntax rules:
 * With two stars, the connection is made *recursively*, e.g. "children**"
   connects to "children" and the children's children, etc.
 * Stripped of '*', each part must be a valid identifier (ASCII).
+* The total string optionally has a label suffix separated by a colon. The
+  label itself may consist of any chars.
+* The string can have a "!" at the very start to suppress warnings for
+  connections to event types that Flexx is not aware of at initialization
+  time (i.e. not corresponding to a property or emitter).
 
-To clarify the order of the special characters: an extreme example would be
-``"foo.bar**!:label"``.
+An extreme example could be ``"!foo.children**.text:mylabel"``, which connects
+to the "text" event of the children (or their children, or their children's
+children etc.) of the ``foo`` attribute. The "!" can be common in cases like
+this to suppress warnings if not all children have a ``text`` event/property.
 
 Labels
 ======

--- a/flexx/event/__init__.py
+++ b/flexx/event/__init__.py
@@ -85,7 +85,7 @@ just use ``for ev in events: ...``.
 In most cases, you will connect to events that are known beforehand,
 like those they correspond to properties, readonlies and emitters. 
 If you connect to an event that is not known (as in the example above)
-it might be a typo and Flexx will display a warning. Use `'!foo'` as a
+it might be a typo and Flexx will display a warning. Use `'foo!'` as a
 connection string (i.e. prepend an exclamation mark) to suppress such
 warnings.
 
@@ -196,8 +196,30 @@ which will get emitted as an event, with the event type matching the name
 of the emitter.
 
 
+Connection string syntax
+------------------------
+
+The strings used to connect events follow a few simple syntax rules:
+
+* The string optionally has a label suffix separated by a colon. The
+  label itself may consist of any chars.
+* The string can have a "!" at the end to suppres warnings for
+  connections to unknown event types. If the string has a label,
+  the exclamation mark comes before it.
+* Connection strings consist of parts separated by dots, thus forming a path.
+  If an element on the path is a property, the connection will automatically
+  reset when that property changes (a.k.a. dynamism, more on this below).
+* Each part can end with one star ('*'), indicating that the part is a list
+  and that a connection should be made for each item in the list. 
+* With two stars, the connection is made *recursively*, e.g. "children**"
+  connects to "children" and the children's children, etc.
+* Stripped of '*', each part must be a valid identifier (ASCII).
+
+To clarify the order of the special characters: an extreme example would be
+``"foo.bar**!:label"``.
+
 Labels
-------
+======
 
 Labels are a feature that makes it possible to infuence the order by
 which event handlers are called, and provide a means to disconnect
@@ -239,7 +261,7 @@ The label can also be used in the
 
 
 Dynamism
---------
+========
 
 Dynamism is a concept that allows one to connect to events for which
 the source can change. For the following example, assume that ``Node``

--- a/flexx/event/__init__.py
+++ b/flexx/event/__init__.py
@@ -85,7 +85,7 @@ just use ``for ev in events: ...``.
 In most cases, you will connect to events that are known beforehand,
 like those they correspond to properties, readonlies and emitters. 
 If you connect to an event that is not known (as in the example above)
-it might be a typo and Flexx will display a warning. Use `'foo!'` as a
+it might be a typo and Flexx will display a warning. Use `'!foo'` as a
 connection string (i.e. prepend an exclamation mark) to suppress such
 warnings.
 
@@ -216,8 +216,8 @@ The strings used to connect events follow a few simple syntax rules:
   time (i.e. not corresponding to a property or emitter).
 
 An extreme example could be ``"!foo.children**.text:mylabel"``, which connects
-to the "text" event of the children (or their children, or their children's
-children etc.) of the ``foo`` attribute. The "!" can be common in cases like
+to the "text" event of the children (and their children, and their children's
+children etc.) of the ``foo`` attribute. The "!" is common in cases like
 this to suppress warnings if not all children have a ``text`` event/property.
 
 Labels

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -208,7 +208,7 @@ class Handler:
             if '!' in s:
                 s = s.replace('!', '')
                 force = '!'
-                console.warn('Exclamation marks in connection strings must'
+                console.warn('Exclamation marks in connection strings must '
                              'come at the end, e.g. "foo.bar!" or "bar!:label".')
             # Check that all parts are identifiers
             parts = s.split('.')

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -197,17 +197,17 @@ class Handler:
             # Separate label and exclamation mark from the string path
             force = fullname.startswith('!')
             s, _, label = fullname.lstrip('!').partition(':')
+            s0 = s
             # Backwards compat: "foo.*.bar* becomes "foo*.bar"
             if '.*.' in s + '.':
-                s = s.replace('.*', '*')
-                console.warn('Connection string syntax "foo.*.bar" is '
-                             'deprecated, use "foo*.bar" instead.')
+                console.warn('Connection string syntax "foo.*.bar" is deprecated, '
+                             'use "%s" instead of "%s":.' % (s, s0))
             # Help put exclamation at the start
             if '!' in s:
                 s = s.replace('!', '')
                 force = True
-                console.warn('Exclamation marks in connection strings must '
-                             'come at the very start, e.g. "!foo.bar".')
+                console.warn('Exclamation marks in connection strings must come at '
+                             'the very start, use "!%s" instead of "%s".' % (s, s0))
             # Check that all parts are identifiers
             parts = s.split('.')
             for part in parts:
@@ -403,6 +403,7 @@ class Handler:
             return  # We cannot seek further
         if len(path) == 1:
             # Path only consists of event type now: make connection
+            # connection.type consists of event type name (no stars) plus a label
             if hasattr(ob, '_IS_HASEVENTS'):
                 connection.objects.append((ob, connection.type))
             # Reached end or continue?

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -200,6 +200,7 @@ class Handler:
             s0 = s
             # Backwards compat: "foo.*.bar* becomes "foo*.bar"
             if '.*.' in s + '.':
+                s = s.replace('.*', '*')
                 console.warn('Connection string syntax "foo.*.bar" is deprecated, '
                              'use "%s" instead of "%s":.' % (s, s0))
             # Help put exclamation at the start

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -240,7 +240,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         if self.__pending_events is not None:
             if not label.startswith('reconnect_'):
                 for ev in self.__pending_events.get(type, []):
-                    handler._add_pending_event(type + ":" + label, ev)  # todo: only label, right??
+                    handler._add_pending_event(label, ev)
         # Send an event to communicate the value of a property
         # if type in self.__properties__:
         #     if self.__props_ever_set.get(type, False):

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -207,14 +207,12 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         # Called when the handlers changed, can be implemented in subclasses
         pass
     
-    def _register_handler(self, event_type, handler):
+    def _register_handler(self, event_type, handler, force=False):
         # Register a handler for the given event type. The type
         # can include a label, e.g. 'mouse_down:foo'.
         # This is called from Handler objects at initialization and when
         # they reconnect (dynamism).
         type, _, label = event_type.partition(':')
-        force = type.endswith('!')
-        type = type.strip('!')
         label = label or handler._name
         handlers = self.__handlers.get(type, None)
         if handlers is None:  # i.e. type not in self.__handlers
@@ -222,7 +220,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             self.__handlers[type] = handlers
             if not force:  # ! means force
                 msg = ('Event type "{}" does not exist. ' +
-                       'Use "{}!" to suppress this warning.')
+                       'Use "!{}" or "!foo.bar.{}" to suppress this warning.')
                 msg = msg.replace('{}', type)
                 if hasattr(self, 'id'):
                     msg = msg.replace('exist.', 'exist on %s.' % self.id)  # Model
@@ -265,7 +263,6 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         # This is called from Handler objects when they dispose and when
         # they reconnect (dynamism).
         type, _, label = type.partition(':')
-        type = type.strip('!')
         handlers = self.__handlers.get(type, ())
         for i in range(len(handlers)-1, -1, -1):
             entry = handlers[i]
@@ -285,7 +282,6 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         """
         info = {} if info is None else info
         type, _, label = type.partition(':')
-        type = type.rstrip('!')
         if len(label):
             raise ValueError('The type given to emit() should not include a label.')
         # Prepare event
@@ -378,7 +374,6 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         if not type:
             raise TypeError('get_event_handlers() missing "type" argument.')
         type, _, label = type.partition(':')
-        type = type.rstrip('!')
         if len(label):
             raise ValueError('The type given to get_event_handlers() '
                              'should not include a label.')

--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -213,15 +213,16 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         # This is called from Handler objects at initialization and when
         # they reconnect (dynamism).
         type, _, label = event_type.partition(':')
-        type = type.lstrip('!')
+        force = type.endswith('!')
+        type = type.strip('!')
         label = label or handler._name
         handlers = self.__handlers.get(type, None)
         if handlers is None:  # i.e. type not in self.__handlers
             handlers = []
             self.__handlers[type] = handlers
-            if not event_type.startswith('!'):  # ! means force
+            if not force:  # ! means force
                 msg = ('Event type "{}" does not exist. ' +
-                       'Use "!{}" to suppress this warning.')
+                       'Use "{}!" to suppress this warning.')
                 msg = msg.replace('{}', type)
                 if hasattr(self, 'id'):
                     msg = msg.replace('exist.', 'exist on %s.' % self.id)  # Model
@@ -239,7 +240,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         if self.__pending_events is not None:
             if not label.startswith('reconnect_'):
                 for ev in self.__pending_events.get(type, []):
-                    handler._add_pending_event(type + ":" + label, ev)  # friend class
+                    handler._add_pending_event(type + ":" + label, ev)  # todo: only label, right??
         # Send an event to communicate the value of a property
         # if type in self.__properties__:
         #     if self.__props_ever_set.get(type, False):
@@ -264,6 +265,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         # This is called from Handler objects when they dispose and when
         # they reconnect (dynamism).
         type, _, label = type.partition(':')
+        type = type.strip('!')
         handlers = self.__handlers.get(type, ())
         for i in range(len(handlers)-1, -1, -1):
             entry = handlers[i]
@@ -283,6 +285,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         """
         info = {} if info is None else info
         type, _, label = type.partition(':')
+        type = type.rstrip('!')
         if len(label):
             raise ValueError('The type given to emit() should not include a label.')
         # Prepare event
@@ -375,6 +378,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         if not type:
             raise TypeError('get_event_handlers() missing "type" argument.')
         type, _, label = type.partition(':')
+        type = type.rstrip('!')
         if len(label):
             raise ValueError('The type given to get_event_handlers() '
                              'should not include a label.')
@@ -420,7 +424,7 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
         
         for s in connection_strings:
             if not (isinstance(s, str) and len(s) > 0):
-                raise ValueError('Connection string must be nonempty strings.')
+                raise ValueError('Connection string must be nonempty string.')
         
         def _connect(func):
             if not callable(func):

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -95,7 +95,8 @@ class HasEventsJS:
             if not (isinstance(s, str) and len(s)):
                 raise ValueError('Connection string must be nonempty strings.')
         
-        return self.__create_Handler(func, func.name or 'anonymous', connection_strings)
+        name = func.name[6:] if func.name.startswith('bound ') else func.name
+        return self.__create_Handler(func, name or 'anonymous', connection_strings)
     
     def __create_PyProperty(self, name):
         self.__create_Property(name)

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -203,7 +203,7 @@ def get_HasEvents_js():
     for name, val in sorted(HasEvents.__dict__.items()):
         if name.startswith(('__', '_HasEvents__')) or not callable(val):
             continue
-        code += py2js(val, 'HasEvents.Ƥ.' + name)
+        code += py2js(val, 'HasEvents.prototype.' + name)
         code += '\n'
     jscode += code
     # Almost done
@@ -214,7 +214,7 @@ def get_HasEvents_js():
 HasEventsJS.JSCODE = get_HasEvents_js()
 
 
-def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.Ƥ'):
+def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
     """ Create the JS equivalent of a subclass of the HasEvents class.
     
     Given a Python class with handlers, properties and emitters, this
@@ -265,19 +265,19 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.Ƥ'):
             else:
                 emitters.append(name)
             # Add function def
-            code = py2js_local(val._func, cls_name + '.Ƥ.' + funcname)
+            code = py2js_local(val._func, cls_name + '.prototype.' + funcname)
             code = code.replace('super()', base_class)  # fix super
             funcs_code.append(code.rstrip())
             # Mark to not bind the func
-            t = '%s.Ƥ.%s.nobind = true;'
+            t = '%s.prototype.%s.nobind = true;'
             funcs_code.append(t % (cls_name, funcname))
             # Has default val?
             if isinstance(val, Property) and val._defaults:
                 default_val = json.dumps(val._defaults[0])
-                t = '%s.Ƥ.%s.default = %s;'
+                t = '%s.prototype.%s.default = %s;'
                 funcs_code.append(t % (cls_name, funcname, default_val))
             # Add type of emitter
-            t = '%s.Ƥ.%s.emitter_type = %s;'
+            t = '%s.prototype.%s.emitter_type = %s;'
             emitter_type = val.__class__.__name__
             funcs_code.append(t % (cls_name, funcname, reprs(emitter_type)))
             funcs_code.append('')
@@ -285,23 +285,23 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.Ƥ'):
             funcname = name  # funcname is simply name, so that super() works
             handlers.append(name)
             # Add function def
-            code = py2js_local(val._func, cls_name + '.Ƥ.' + funcname)
+            code = py2js_local(val._func, cls_name + '.prototype.' + funcname)
             code = code.replace('super()', base_class)  # fix super
             funcs_code.append(code.rstrip())
             # Mark to not bind the func
-            t = '%s.Ƥ.%s.nobind = true;'
+            t = '%s.prototype.%s.nobind = true;'
             funcs_code.append(t % (cls_name, funcname))
             # Add connection strings to the function object
-            t = '%s.Ƥ.%s._connection_strings = %s;'
+            t = '%s.prototype.%s._connection_strings = %s;'
             funcs_code.append(t % (cls_name, funcname, reprs(val._connection_strings)))
             funcs_code.append('')
         elif callable(val):
-            code = py2js_local(val, cls_name + '.Ƥ.' + name)
+            code = py2js_local(val, cls_name + '.prototype.' + name)
             code = code.replace('super()', base_class)  # fix super
             funcs_code.append(code.rstrip())
             funcs_code.append('')
         elif name in OK_MAGICS:
-            t = '%s.Ƥ.%s = %s;'
+            t = '%s.prototype.%s = %s;'
             const_code.append(t % (cls_name, name, reprs(val)))
         elif name.startswith('__'):
             pass  # we create our own __emitters__, etc.
@@ -311,9 +311,9 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.Ƥ'):
             except Exception as err:  # pragma: no cover
                 raise ValueError('Attributes on JS HasEvents class must be '
                                  'JSON compatible.\n%s' % str(err))
-            #const_code.append('%s.Ƥ.%s = JSON.parse(%s)' %
+            #const_code.append('%s.prototype.%s = JSON.parse(%s)' %
             #                  (cls_name, name, reprs(serialized)))
-            const_code.append('%s.Ƥ.%s = %s;' % (cls_name, name, serialized))
+            const_code.append('%s.prototype.%s = %s;' % (cls_name, name, serialized))
     
     if const_code:
         total_code.append('')

--- a/flexx/event/tests/test_both.py
+++ b/flexx/event/tests/test_both.py
@@ -887,7 +887,7 @@ def test_handler_get_name(Person):
     return res1
 
 
-@run_in_both(Person, "[['first_name', ['first_name:func1']], ['last_name', ['last_name:func1']]]")
+@run_in_both(Person, "[['first_name', ['first_name']], ['last_name', ['last_name']]]")
 def test_handler_get_connection_info(Person):
     res1 = []
     
@@ -898,7 +898,12 @@ def test_handler_get_connection_info(Person):
     name = Person()
     handler1 = name.connect(func1, 'first_name', 'last_name')
     
-    return handler1.get_connection_info()
+    info = handler1.get_connection_info()
+    
+    # Strip the labels, because on CI the func name becomes "anonymous"
+    info[0][1][0] = info[0][1][0].split(':')[0]
+    info[1][1][0] = info[1][1][0].split(':')[0]
+    return info
 
 
 class Simple1(event.HasEvents):

--- a/flexx/event/tests/test_handlers.py
+++ b/flexx/event/tests/test_handlers.py
@@ -428,13 +428,13 @@ def test_connectors1():
     
     # Supress warn
     with capture_log('warning') as log:
-        h = x.connect(foo, 'b!')
+        h = x.connect(foo, '!b')
     assert not log
     x._HasEvents__handlers.pop('b')
     
     # Supress warn, with label
     with capture_log('warning') as log:
-        h = x.connect(foo, 'b!:meh')
+        h = x.connect(foo, '!b:meh')
     assert not log
     x._HasEvents__handlers.pop('b')
     
@@ -442,12 +442,14 @@ def test_connectors1():
     with capture_log('warning') as log:
         h = x.connect(foo, 'b:meh!')
     assert log
+    assert 'does not exist' in log[0]
     x._HasEvents__handlers.pop('b')
     
     # Invalid syntax - but fix and warn
     with capture_log('warning') as log:
-        h = x.connect(foo, '!b:meh')
+        h = x.connect(foo, 'b!:meh')
     assert log
+    assert 'Exclamation mark' in log[0]
 
 
 def test_connectors2():
@@ -468,20 +470,21 @@ def test_connectors2():
     
     # Supress warn
     with capture_log('warning') as log:
-        h = x.connect(foo, 'sub*.b!')
+        h = x.connect(foo, '!sub*.b')
     assert not log
     y._HasEvents__handlers.pop('b')
     
     # Supress warn, with label
     with capture_log('warning') as log:
-        h = x.connect(foo, 'sub*.b!:meh')
+        h = x.connect(foo, '!sub*.b:meh')
     assert not log
     y._HasEvents__handlers.pop('b')
     
     # Invalid syntax - but fix and warn
     with capture_log('warning') as log:
-        h = x.connect(foo, '!sub*.b:meh')
+        h = x.connect(foo, 'sub*.!b:meh')
     assert log
+    assert 'Exclamation mark' in log[0]
     y._HasEvents__handlers.pop('b')
     
     # Position of *
@@ -500,13 +503,13 @@ def test_connectors2():
     
     # Mix it
     with capture_log('warning') as log:
-        h = x.connect(foo, 'aa*!')
+        h = x.connect(foo, '!aa*')
     assert not log
     with capture_log('warning') as log:
-        h = x.connect(foo, 'aa**!')
+        h = x.connect(foo, '!aa**')
     assert not log
     with capture_log('warning') as log:
-        h = x.connect(foo, 'aa**!:meh')  # why not
+        h = x.connect(foo, '!aa**:meh')  # why not
     assert not log
 
 

--- a/flexx/pyscript/examples/js_module.js
+++ b/flexx/pyscript/examples/js_module.js
@@ -21,7 +21,7 @@
 var _pyfunc_hasattr = function (ob, name) { // nargs: 2
     return (ob !== undefined) && (ob !== null) && (ob[name] !== undefined);
 };
-var _pyfunc_instantiate = function (ob, args) { // nargs: 2
+var _pyfunc_op_instantiate = function (ob, args) { // nargs: 2
     if ((typeof ob === "undefined") ||
             (typeof window !== "undefined" && window === ob) ||
             (typeof global !== "undefined" && global === ob))
@@ -36,7 +36,7 @@ var _pyfunc_instantiate = function (ob, args) { // nargs: 2
         ob.__init__.apply(ob, args);
     }
 };
-var _pyfunc_mult = function (a, b) { // nargs: 2
+var _pyfunc_op_mult = function (a, b) { // nargs: 2
     if ((typeof a === 'number') + (typeof b === 'number') === 1) {
         if (a.constructor === String) return _pymeth_repeat.call(a, b);
         if (b.constructor === String) return _pymeth_repeat.call(b, a);
@@ -64,38 +64,37 @@ var Bar, Foo;
 // and in combination with browserify and related tools.
 
 Foo = function () {
-    _pyfunc_instantiate(this, arguments);
+    _pyfunc_op_instantiate(this, arguments);
 }
-Foo.Ƥ = Foo.prototype;
-Foo.Ƥ._base_class = Object;
-Foo.Ƥ._class_name = "Foo";
+Foo.prototype._base_class = Object;
+Foo.prototype._class_name = "Foo";
 
-Foo.Ƥ.a_constant = [1, 2, 3];
-Foo.Ƥ.ham = function (x) {
+Foo.prototype.a_constant = [1, 2, 3];
+Foo.prototype.ham = function ham (x) {
     this.x = x;
     return null;
 };
 
-Foo.Ƥ.eggs = function (y) {
-    this.y = _pyfunc_mult(this.x, y);
+Foo.prototype.eggs = function eggs (y) {
+    this.y = _pyfunc_op_mult(this.x, y);
     _pyfunc_hasattr(y, str);
     return null;
 };
 
 
 Bar = function () {
-    _pyfunc_instantiate(this, arguments);
+    _pyfunc_op_instantiate(this, arguments);
 }
-Bar.Ƥ = Bar.prototype = Object.create(Foo.Ƥ);
-Bar.Ƥ._base_class = Foo.Ƥ;
-Bar.Ƥ._class_name = "Bar";
+Bar.prototype = Object.create(Foo.prototype);
+Bar.prototype._base_class = Foo.prototype;
+Bar.prototype._class_name = "Bar";
 
-Bar.Ƥ.bla = function (z) {
+Bar.prototype.bla = function bla (z) {
     console.log(z);
     return null;
 };
 
 
 
-return {Bar, Foo};
+return {};
 })); 

--- a/flexx/pyscript/functions.py
+++ b/flexx/pyscript/functions.py
@@ -143,7 +143,8 @@ def js_rename(jscode, cur_name, new_name):
     Returns:
         jscode (str): the modified JavaScript source code
     """
-    
+    jscode = jscode.replace('function %s' % cur_name,
+                            'function %s' % (new_name.split('.')[-1]), 1)
     jscode = jscode.replace('%s = function' % cur_name, 
                             '%s = function' % (new_name), 1)
     jscode = jscode.replace('%s.prototype' % cur_name, 

--- a/flexx/pyscript/functions.py
+++ b/flexx/pyscript/functions.py
@@ -149,8 +149,6 @@ def js_rename(jscode, cur_name, new_name):
                             '%s = function' % (new_name), 1)
     jscode = jscode.replace('%s.prototype' % cur_name, 
                             '%s.prototype' % new_name)
-    jscode = jscode.replace('%s.Ƥ' % cur_name, 
-                            '%s.Ƥ' % new_name)
     jscode = jscode.replace('_class_name = "%s"' % cur_name, 
                             '_class_name = "%s"' % new_name)
     if '.' in new_name:

--- a/flexx/pyscript/functions.py
+++ b/flexx/pyscript/functions.py
@@ -3,6 +3,7 @@ import sys
 import types
 import inspect
 import hashlib
+import tempfile
 import subprocess
 
 from . import Parser
@@ -178,33 +179,61 @@ def get_node_exe():
     return NODE_EXE
 
 
-def evaljs(jscode, whitespace=True):
+_eval_count = 0
+
+def evaljs(jscode, whitespace=True, print_result=True):
     """ Evaluate JavaScript code in Node.js.
     
     parameters:
         jscode (str): the JavaScript code to evaluate.
         whitespace (bool): if whitespace is False, the whitespace
             is removed from the result. Default True.
+        print_result (bool): whether to print the result of the evaluation.
+            Default True. If False, larger pieces of code can be evaluated
+            because we can use file-mode.
+    
     returns:
         result (str): the last result as a string.
     """
+    global _eval_count
+    
+    # Prepare command
+    if len(jscode) > 2**14:
+        if print_result:
+            # Strictly speaking, this is a limitation of Windows, but come-on!
+            raise RuntimeError('evaljs() wont send more than 16 kB of code '
+                               'over the command line, but cannot use a file '
+                               'unless print_result is False.')
+        _eval_count += 1
+        fname = 'pyscript_%i_%i.js' % (os.getpid(), _eval_count)
+        filename = os.path.join(tempfile.gettempdir(), fname)
+        with open(filename, 'wb') as f:
+            f.write(jscode.encode())
+        cmd = [get_node_exe(), '--use_strict', filename]
+    else:
+        filename = None
+        p_or_e = ['-p', '-e'] if print_result else ['-e']
+        cmd = [get_node_exe(), '--use_strict'] + p_or_e + [jscode]
+        if sys.version_info[0] < 3:
+            cmd = [c.encode('raw_unicode_escape') for c in cmd]
     
     # Call node
-    cmd = [get_node_exe(), '--use_strict', '-p', '-e', jscode]
-    if sys.version_info[0] < 3:
-        cmd = [c.encode('raw_unicode_escape') for c in cmd]
     try:
         res = subprocess.check_output(cmd)
-    except FileNotFoundError as err:
-        raise Exception('%s - The code is probably too big' % str(err))
     except Exception as err:
         err = err.output.decode()
         err = err[:200] + '...' if len(err) > 200 else err
         raise Exception(err)
+    finally:
+        if filename is not None:
+            try:
+                os.remove(filename)
+            except Exception:
+                pass
     
-    # process
+    # Process result
     res = res.decode().rstrip()
-    if res.endswith('undefined'):
+    if print_result and res.endswith('undefined'):
         res = res[:-9].rstrip()
     if not whitespace:
         res = res.replace('\n', '').replace('\t', '').replace(' ', '')

--- a/flexx/pyscript/parser0.py
+++ b/flexx/pyscript/parser0.py
@@ -106,7 +106,7 @@ class Parser0:
     }
     
     ATTRIBUTE_MAP = {
-        '__class__': 'constructor.Ƥ',
+        '__class__': 'constructor.prototype',
     }
     
     BINARY_OP = {
@@ -305,7 +305,7 @@ class Parser0:
         """
         nstype, nsname, ns = self._stack[-1]
         if nstype == 'class':
-            return nsname + '.Ƥ.' + name
+            return nsname + '.prototype.' + name
         else:
             return name
     

--- a/flexx/pyscript/parser2.py
+++ b/flexx/pyscript/parser2.py
@@ -701,7 +701,9 @@ class Parser2(Parser1):
         
         # Init function definition
         code = []
+        func_name = ''
         if not lambda_:
+            func_name = node.name
             prefixed = self.with_prefix(node.name)
             if prefixed == node.name:  # normal function vs method
                 self.vars.add(node.name)
@@ -709,9 +711,9 @@ class Parser2(Parser1):
             code.append(self.lf('%s = ' % prefixed))
             #code.append('function %s (' % node.name)
         if binder:
-            code.append('(function (')
+            code.append('(function %s (' % func_name)
         else:
-            code.append('function (')
+            code.append('function %s (' % func_name)
         
         # Collect args
         argnames = []

--- a/flexx/pyscript/parser2.py
+++ b/flexx/pyscript/parser2.py
@@ -223,6 +223,24 @@ RAW_DOC_WARNING = ('Function %s only has a docstring, which used to be '
                    'docstring, or add "pass" to the function body to prevent '
                    'this behavior.')
 
+JS_RESERVED_WORDS = set()
+
+
+# https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
+RESERVED = { # Reserved keywords as of ECMAScript 6
+            'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
+            'default', 'delete', 'do', 'else', 'export', 'extends', 'finally',
+            'for', 'function', 'if', 'import', 'in', 'instanceof', 'new',
+            'return', 'super', 'switch', 'this', 'throw', 'try', 'typeof',
+            'var', 'void', 'while', 'with', 'yield',
+            # Future reserved keywords
+            'implements', 'interface', 'let', 'package', 'private',
+            'protected', 'public', 'static', 'enum',
+            'await',  # only in module code
+            'true', 'false', 'null',
+            }
+ 
+ 
 class Parser2(Parser1):
     """ Parser that adds control flow, functions, classes, and exceptions.
     """
@@ -703,17 +721,16 @@ class Parser2(Parser1):
         code = []
         func_name = ''
         if not lambda_:
-            func_name = node.name
+            func_name = '' if node.name in RESERVED else node.name
             prefixed = self.with_prefix(node.name)
             if prefixed == node.name:  # normal function vs method
                 self.vars.add(node.name)
                 self._seen_func_names.add(node.name)
             code.append(self.lf('%s = ' % prefixed))
             #code.append('function %s (' % node.name)
-        if binder:
-            code.append('(function %s (' % func_name)
-        else:
-            code.append('function %s (' % func_name)
+        code.append('%sfunction %s%s(' % ('(' if binder else '',
+                                          func_name,
+                                          ' ' if func_name else ''))
         
         # Collect args
         argnames = []

--- a/flexx/pyscript/parser2.py
+++ b/flexx/pyscript/parser2.py
@@ -836,7 +836,7 @@ class Parser2(Parser1):
         elif base_class.lower() == 'object':  # maybe Python "object"
             base_class = 'Object'
         else:
-            base_class = base_class + '.Ƥ'
+            base_class = base_class + '.prototype'
         
         # Define function that acts as class constructor
         code = []
@@ -880,7 +880,7 @@ class Parser2(Parser1):
             raise JSError('can only use super() inside a method.')
         
         base_class = nsname2
-        return '%s.Ƥ._base_class' % base_class
+        return '%s.prototype._base_class' % base_class
     
     
     #def parse_With
@@ -914,11 +914,9 @@ def get_class_definition(name, base='Object', docstring=''):
     code.append('}')
     
     if base != 'Object':
-        code.append('%s.Ƥ = %s.prototype = Object.create(%s);' % (name, name, base))
-    else:
-        code.append('%s.Ƥ = %s.prototype;' % (name, name))
-    code.append('%s.Ƥ._base_class = %s;' % (name, base))
-    code.append('%s.Ƥ._class_name = %s;' % (name, reprs(name.split('.')[-1])))
+        code.append('%s.prototype = Object.create(%s);' % (name, base))
+    code.append('%s.prototype._base_class = %s;' % (name, base))
+    code.append('%s.prototype._class_name = %s;' % (name, reprs(name.split('.')[-1])))
     
     code.append('')
     return code

--- a/flexx/pyscript/parser2.py
+++ b/flexx/pyscript/parser2.py
@@ -227,7 +227,8 @@ JS_RESERVED_WORDS = set()
 
 
 # https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar
-RESERVED = { # Reserved keywords as of ECMAScript 6
+RESERVED = {'true', 'false', 'null',
+            # Reserved keywords as of ECMAScript 6
             'break', 'case', 'catch', 'class', 'const', 'continue', 'debugger',
             'default', 'delete', 'do', 'else', 'export', 'extends', 'finally',
             'for', 'function', 'if', 'import', 'in', 'instanceof', 'new',
@@ -237,9 +238,8 @@ RESERVED = { # Reserved keywords as of ECMAScript 6
             'implements', 'interface', 'let', 'package', 'private',
             'protected', 'public', 'static', 'enum',
             'await',  # only in module code
-            'true', 'false', 'null',
             }
- 
+
  
 class Parser2(Parser1):
     """ Parser that adds control flow, functions, classes, and exceptions.

--- a/flexx/pyscript/tests/test_parser1.py
+++ b/flexx/pyscript/tests/test_parser1.py
@@ -288,7 +288,7 @@ class TestExpressions:
         # Class variables don't get a var
         code = py2js('class Foo:\n  bar=3\n  bar = bar + 1')
         assert code.count('bar') == 3
-        assert code.count('Foo.Ƥ.bar') == 3
+        assert code.count('Foo.prototype.bar') == 3
     
     def test_aug_assignments(self):
         # assign + bin op

--- a/flexx/pyscript/tests/test_parser2.py
+++ b/flexx/pyscript/tests/test_parser2.py
@@ -297,7 +297,7 @@ class TestFunctions:
         lines = [line for line in code.split('\n') if line]
         
         assert len(lines) == 4  # only three lines + definition
-        assert lines[1] == 'func1 = function () {'  # no args
+        assert lines[1] == 'func1 = function func1 () {'  # no args
         assert lines[2].startswith('  ')  # indented
         assert lines[3] == '};'  # dedented
     
@@ -310,7 +310,7 @@ class TestFunctions:
         lines = [line for line in code.split('\n') if line]
         
         assert len(lines) == 4  # only three lines + definition
-        assert lines[1] == 'method1 = function () {'  # no args, no self/this
+        assert lines[1] == 'method1 = function method1 () {'  # no args, no self/this
         assert lines[2].startswith('  ')  # indented
         assert lines[3] == '};'  # dedented
     
@@ -322,7 +322,7 @@ class TestFunctions:
         code = py2js(func)
         lines = [line for line in code.split('\n') if line]
         
-        assert lines[1] == 'func = function (foo, bar) {'
+        assert lines[1] == 'func = function func (foo, bar) {'
         assert '2' in code
         
         assert evaljs(code + 'func(2)') == '0'

--- a/flexx/ui/examples/classic_web_dev.py
+++ b/flexx/ui/examples/classic_web_dev.py
@@ -18,7 +18,7 @@ be styled either using their ``style`` property, or by providing CSS
 and using the ``css_class`` property.
 
 A programmer can build content using these html widgets (as in list 1),
-or embed plain of HTML inside one such widget (as in list 2). In the
+or embed plain HTML inside one such widget (as in list 2). In the
 first approach the widgets can still be used in the Flexx way, but the
 second approach is a bit "lighter" (e.g. the elements don't have a
 representation on the Python side).

--- a/flexx/ui/layouts/_box.py
+++ b/flexx/ui/layouts/_box.py
@@ -237,7 +237,7 @@ class BoxLayout(BaseBoxLayout):
             for widget in self.children:
                 widget._check_real_size()
         
-        @event.connect('orientation', 'children', 'children.*.flex')
+        @event.connect('orientation', 'children', 'children*.flex')
         def __set_flexes(self, *events):
             ori = self.orientation
             i = 0 if ori in (0, 'h', 'hr') else 1
@@ -339,7 +339,7 @@ class BoxPanel(BaseBoxLayout):
             self.phosphor = _phosphor_boxpanel.BoxPanel()
             self.node = self.phosphor.node
         
-        @event.connect('orientation', 'children', 'children.*.flex')
+        @event.connect('orientation', 'children', 'children*.flex')
         def __set_flexes(self, *events):
             i = 0 if self.orientation in (0, 'h', 'hr') else 1
             for widget in self.children:

--- a/flexx/ui/layouts/_form.py
+++ b/flexx/ui/layouts/_form.py
@@ -221,13 +221,13 @@ class FormLayout(BaseTableLayout):
             if widget._title_elem:
                 del widget._title_elem
         
-        @event.connect('children', 'children.*.flex')
+        @event.connect('children', 'children*.flex')
         def __update_flexes(self, *events):
             for widget in self.children:
                 widget.outernode.vflex = widget.flex[1]
             self._apply_table_layout()
         
-        @event.connect('children', 'children.*.title')
+        @event.connect('children', 'children*.title')
         def __update_titles(self, *events):
             for widget in self.children:
                 if hasattr(widget, '_title_elem'):

--- a/flexx/ui/layouts/_grid.py
+++ b/flexx/ui/layouts/_grid.py
@@ -90,8 +90,8 @@ class GridPanel(Layout):
                 return False
             _phosphor_messaging.installMessageHook(self.phosphor, msg_hook)
         
-        @event.connect('children', 'children.*.pos',
-                       'children.*.flex', 'children.*.base_size')
+        @event.connect('children', 'children*.pos',
+                       'children*.flex', 'children*.base_size')
         def __update_positions(self, *events):
             self._child_limits_changed()
         

--- a/flexx/ui/layouts/_pinboard.py
+++ b/flexx/ui/layouts/_pinboard.py
@@ -44,7 +44,7 @@ class PinboardLayout(Layout):
             self.phosphor = _phosphor_panel.Panel()
             self.node = self.phosphor.node
         
-        @event.connect('children', 'children.*.pos')
+        @event.connect('children', 'children*.pos')
         def __pos_changed(self, *events):
             for child in self.children:
                 pos = child.pos
@@ -52,7 +52,7 @@ class PinboardLayout(Layout):
                 st.left = pos[0] + "px" if (pos[0] > 1) else pos[0] * 100 + "%"
                 st.top = pos[1] + "px" if (pos[1] > 1) else pos[1] * 100 + "%"
         
-        @event.connect('children', 'children.*.base_size')
+        @event.connect('children', 'children*.base_size')
         def __size_changed(self, *events):
             for child in self.children:
                 size = child.base_size

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -307,7 +307,7 @@ class TreeWidget(Widget):
                     for i in self.items:
                         i.selected = False
         
-        @event.connect('items**.!mouse_click')
+        @event.connect('!items**.mouse_click')
         def __item_clicked(self, *events):
             if self.max_selected == 0:
                 # No selection allowed


### PR DESCRIPTION
* Fixes #194: formalize the syntax for connection strings.
* Make sure normalization/checks are done in the right places.
* Fixes connection string that end in deep connector.
* Fixes a few other corner cases that where bugs but simply never showed up yet.
* The code grew somewhat, so I had to finally make `evaljs` pass the code to `node` via a file.
* Which gave some space, so I got rid of the `Ƥ` placeholder for `prototype`.
* Make functions not anonymous (which makes handlers for which no label is specified sill still have a sensible label).