### PR TITLE
Fix tabindex and still make key events Just Work

### DIFF
--- a/flexx/app/model.py
+++ b/flexx/app/model.py
@@ -518,6 +518,12 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
                 self._id, reprs(name), reprs(txt))
             self._session._exec(cmd)
     
+    def _register_handler(self, *args):
+        event_type = args[0].split(':')[0].strip('!')
+        if not self.get_event_handlers(event_type):
+            self.call_js('_new_event_type_hook("%s")' % event_type)
+        return super()._register_handler(*args)
+    
     def _handlers_changed_hook(self):
         handlers = self._HasEvents__handlers
         types = [name for name in handlers.keys() if handlers[name]]
@@ -590,6 +596,17 @@ class Model(with_metaclass(ModelMeta, event.HasEvents)):
         
         def init(self):
             """ Can be overloaded by subclasses to initialize the model.
+            """
+            pass
+        
+        def _register_handler(self, *args):
+            event_type = args[0].split(':')[0].strip('!')
+            if not self.get_event_handlers(event_type):
+                self._new_event_type_hook(event_type)
+            return super()._register_handler(*args)
+        
+        def _new_event_type_hook(self, event_type):
+            """ Called when a new event is registered.
             """
             pass
         


### PR DESCRIPTION
This makes `Model` provide a method hook in JS that gets called when a handler is connected to an event that was previously unconnected. In `Widget` we use that hook to check if we need to support key events and set the `tab_index` if necessary. Over time, we might want to use this hook for other purposes as well (e.g. mouse events prevent-default stuff?)