### PR TITLE
Preventing default key press action by overloading key_press emitter

### DIFF
--- a/flexx/pyscript/functions.py
+++ b/flexx/pyscript/functions.py
@@ -51,8 +51,8 @@ def py2js(ob=None, new_name=None, **parser_options):
                 raise ValueError('Could not get source code for object %r: %s' %
                                  (ob, err))
             if getattr(ob, '__name__', '') in ('', '<lambda>'):
-                raise ValueError('py2js() got anonymous object from "%s", line %i, %r.' %
-                                 (fname, linenr, ob))
+                raise ValueError('py2js() got anonymous function from '
+                                 '"%s", line %i, %r.' % (fname, linenr, ob))
             # Normalize indentation
             indent = len(lines[0]) - len(lines[0].lstrip())
             lines = [line[indent:] for line in lines]

--- a/flexx/pyscript/functions.py
+++ b/flexx/pyscript/functions.py
@@ -41,15 +41,18 @@ def py2js(ob=None, new_name=None, **parser_options):
         if isinstance(ob, str):
             thetype = 'str'
             pycode = ob
-        elif isinstance(ob, type) or isinstance(ob, (types.FunctionType,
-                                                     types.MethodType)):
+        elif isinstance(ob, (type, types.FunctionType, types.MethodType)):
             thetype = 'class' if isinstance(ob, type) else 'def'
             # Get code
             try:
+                fname = inspect.getsourcefile(ob)
                 lines, linenr = inspect.getsourcelines(ob)
             except Exception as err:
                 raise ValueError('Could not get source code for object %r: %s' %
                                  (ob, err))
+            if getattr(ob, '__name__', '') in ('', '<lambda>'):
+                raise ValueError('py2js() got anonymous object from "%s", line %i, %r.' %
+                                 (fname, linenr, ob))
             # Normalize indentation
             indent = len(lines[0]) - len(lines[0].lstrip())
             lines = [line[indent:] for line in lines]

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -683,7 +683,7 @@ class Widget(Model):
               modifier keys pressed down at the time of the event.
             """
             return self._create_key_event(e)
-
+        
         @event.emitter
         def key_up(self, e):
             """ Event emitted when a key is released while
@@ -693,18 +693,27 @@ class Widget(Model):
 
         @event.emitter
         def key_press(self, e):
-            """ Event emitted when a key is pressed down. This event
-            does not fire for the pressing of a modifier keys. See
-            key_down for details.
+            """ Event emitted when a key is pressed down. This event does not
+            fire for the pressing of a modifier keys. See key_down for details.
+            
+            A browser may associate certain actions with certain key presses.
+            If this browser action is unwanted, it can be disabled by
+            overloading this emitter:
+            
+            .. code-block:: py
+            
+                @event.emitter
+                def key_press(self, e):
+                    # Prevent browser's default reaction to function keys
+                    ev = super().key_press(e)
+                    if ev.key.startswith('F'):
+                        e.preventDefault()
+                    return ev
+            
             """
             return self._create_key_event(e)
 
         def _create_key_event(self, e):
-            # If there are listeners for key events, prevent default events
-            # like search, print and tab switching. The tabindex is a pretty
-            # good indicator that this widget wants key events.
-            if self.tabindex is not None:
-                e.preventDefault()
             # https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent
             # key: chrome 51, ff 23, ie 9
             # code: chrome ok, ff 32, ie no


### PR DESCRIPTION
Essentially undoes #251 and adds docs on how to do it in a different way.

Also snuck in small fix to `py2js`.