### PR TITLE
Making it possible to run Flexx via a 3d party Tornado app (aka JLab integration part 2)

### DIFF
--- a/flexx/__main__.py
+++ b/flexx/__main__.py
@@ -80,7 +80,7 @@ class CLI:
             return self.cmd_help('info')
         port = int(port)
         try:
-            print(http_fetch('http://localhost:%i/_cmd/info' % port))
+            print(http_fetch('http://localhost:%i/flexx/cmd/info' % port))
         except FetchError:
             print('There appears to be no local server at port %i' % port)
     
@@ -91,7 +91,7 @@ class CLI:
             return self.cmd_help('stop')
         port = int(port)
         try:
-            print(http_fetch('http://localhost:%i/_cmd/stop' % port))
+            print(http_fetch('http://localhost:%i/flexx/cmd/stop' % port))
             print('stopped server at %i' % port)
         except FetchError:
             print('There appears to be no local server at port %i' % port)
@@ -103,7 +103,7 @@ class CLI:
         if port is None:
             return self.cmd_help('log')
         print('not yet implemented')
-        #print(http_fetch('http://localhost:%i/_cmd/log' % int(port)))
+        #print(http_fetch('http://localhost:%i/flexx/cmd/log' % int(port)))
 
 
 class FetchError(Exception):

--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -982,7 +982,7 @@ class SessionAssets:
     def _get_page(self, js_assets, css_assets, link, export):
         """ Compose index page.
         """
-        pre_path = '' if export else '/'
+        pre_path = '_assets' if export else '/flexx/assets'
         
         codes = []
         for assets in [css_assets, js_assets]:
@@ -993,9 +993,9 @@ class SessionAssets:
                     if asset.name.startswith('embed/'):
                         html = asset.to_html('', 0)
                     elif self._store.get_asset(asset.name) is not asset:
-                        html = asset.to_html(pre_path + '_assets/%s/{}' % self.id, link)
+                        html = asset.to_html(pre_path + '/%s/{}' % self.id, link)
                     else:
-                        html = asset.to_html(pre_path + '_assets/shared/{}', link)
+                        html = asset.to_html(pre_path + '/shared/{}', link)
                 codes.append(html)
             codes.append('')  # whitespace between css and js assets
         

--- a/flexx/app/clientcore.py
+++ b/flexx/app/clientcore.py
@@ -103,8 +103,7 @@ class FlexxJS:
             address = location.hostname
             if location.port:
                 address += ':' + location.port
-            address += '/' + self.app_name
-            self.ws_url = 'ws://%s/ws' % address
+            self.ws_url = 'ws://%s/flexx/ws/%s' % (address, self.app_name)
         
         # Open web socket in binary mode
         self.ws = ws = WebSocket(window.flexx.ws_url)

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -37,7 +37,8 @@ def create_server(host=None, port=None, new_loop=False, backend='tornado'):
     
     Arguments:
         host (str): The hostname to serve on. By default
-            ``flexx.config.hostname`` is used.
+            ``flexx.config.hostname`` is used. If ``False``, do not listen
+            (e.g. when integrating with an existing Tornado application).
         port (int, str): The port number. If a string is given, it is
             hashed to an ephemeral port number. By default
             ``flexx.config.port`` is used.

--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -286,7 +286,7 @@ def init_notebook():
     # Pop the first JS asset that sets flexx.app_name and flexx.session_id
     # We set these in a way that it does not end up in exported notebook.
     js_assets.pop(0)
-    url = 'ws://%s:%i/%s/ws' % (host, port, session.app_name)
+    url = 'ws://%s:%i/flexx/ws/%s' % (host, port, session.app_name)
     flexx_pre_init = """<script>window.flexx = window.flexx || {};
                                 window.flexx.app_name = "%s";
                                 window.flexx.session_id = "%s";

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -706,13 +706,18 @@ class WSHandler(tornado.websocket.WebSocketHandler):
     def check_origin(self, origin):
         """ Handle cross-domain access; override default same origin policy.
         """
-        host, port = self.application._flexx_serving  # set by us
-        incoming_host = urlparse(origin).hostname
-        if host == 'localhost':
+        # http://www.tornadoweb.org/en/stable/_modules/tornado/websocket.html
+        #WebSocketHandler.check_origin
+        
+        serving_host = self.request.headers.get("Host")
+        serving_hostname = serving_host.split(':')[0]
+        connecting_host = urlparse(origin).netloc
+        
+        if serving_hostname == 'localhost':
             return True  # Safe
-        elif host == '0.0.0.0':
+        elif serving_hostname == '0.0.0.0':
             return True  # we cannot know if the origin matches
-        elif host == incoming_host:
+        elif serving_host == connecting_host:
             return True
         else:
             logger.info('Connection refused from %s' % origin)

--- a/flexx/pyscript/parser2.py
+++ b/flexx/pyscript/parser2.py
@@ -613,7 +613,7 @@ class Parser2(Parser1):
     def parse_ListComp(self, node):
         
         elt = ''.join(self.parse(node.element_node))
-        code = ['(function list_comprehenson () {', 'var res = [];']
+        code = ['(function list_comprehension () {', 'var res = [];']
         vars = []
         
         for iter, comprehension in enumerate(node.comp_nodes):

--- a/flexx/ui/examples/serve_data.py
+++ b/flexx/ui/examples/serve_data.py
@@ -9,8 +9,9 @@ is shared between sessions. In the latter, the data is specific for the
 session (the link to the data includes the session id).
 
 Note that ``add_shared_data()`` and ``add_data()`` both return the link
-to the data for convenience. Shared data is always served at
-'_data/shared/filename.ext', so we just use that explicitly here.
+to the data for convenience. Shared data is served at
+'/flexx/data/shared/filename.ext', though one can also use the relative path
+'_data/shared/filename.ext', which also works for exported apps.
 
 Similarly, the data provided by the server can be obtained using Ajax
 (i.e. XMLHttpRequest).


### PR DESCRIPTION
Earlier on we made Flexx host its assets and data at `/_assets/...` and `/_data/...`, reserving the underscore for non-app Flexx stuff. This PR changes this so that all things that Flexx serves---except app pages---are prefixed by `/flexx/` (and `flexx` is an invalid app name). This way, when Flexx is run in another Tornado app (e.g. JLab, and possibly the notebook) we avoid name clashes.

This also splits the Tornado request handler in two parts: the `AppHandler` only serves apps and the app index page. The `MainHandler` handles serves everything else (using the `/flexx/` prefix). That way, we can only add the `MainHandler` when no app pages need to be served.

Along the same line, the `WSHandler` (websocket handler) now serves at `/flexx/ws/...`.

Further, there are a few changes related to the ioloop and cross-origin-check to make certain parts of Flexx more agnostic about its own internals (i.e. easier to integrate with other apps).

