### PR TITLE
Fix loading assets

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -5,5 +5,8 @@ config = Config('flexx', '~appdata/.flexx.cfg',
     hostname=('localhost', str, 'The default hostname to serve apps.'),
     port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
     webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
-    ws_timeout=(20, int, 'If the websocket is idle for this time, it is closed.')
+    ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
+                         'it is closed.'),
+    bundle_all=(False, bool, 'Whether to serve all known modules, '
+                             'or only the modules that we know are used.'),
     )


### PR DESCRIPTION
Modules that were not served, but needed later were not loaded. This fixes that. Also add a config option to load *all* modules corresponding to imported Model classes (and their dependencies), so that larger apps that dynamically instantiate classes can still load everything beforehand.