### PR TITLE
Show spinner during startup

### DIFF
--- a/flexx/app/asset.py
+++ b/flexx/app/asset.py
@@ -282,4 +282,5 @@ class Bundle(Asset):
             source.append(s)
         source.insert(0, '/* Bundle contents:\n' + '\n'.join(toc) + '\n*/\n')
         source.insert(0, HEADER)
+        source.append('window.flexx.spin("%s ");' % ('*' * len(self.modules)))
         return '\n\n'.join(source)

--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -31,6 +31,12 @@ INDEX = """
 
 <body id='body'>
 
+<div class='flx-spinner' style='position:absolute; top:10%; bottom:10%;
+left:25%; right:25%; background:#fff; color:#555; text-align:center;
+word-break: break-all; border-radius:0.5em; padding:0.5em;'>
+Starting Flexx app <div style='font-size:50%; color:#66A;'></div>
+</div>
+
 ASSET-HOOK
 
 </body>

--- a/flexx/app/clientcore.py
+++ b/flexx/app/clientcore.py
@@ -85,8 +85,8 @@ class Flexx:
     
     def spin(self, text='*'):
         """
-        var el = document.body.children[0];
-        window.el = el;
+        if (!window.document.body) {return;}
+        var el = window.document.body.children[0];
         if (el && el.classList.contains("flx-spinner")) {
             if (text === null) {
                 el.style.display = 'none';  // Stop the spinner

--- a/flexx/app/clientcore.py
+++ b/flexx/app/clientcore.py
@@ -83,6 +83,19 @@ class Flexx:
         else:
             return self.instances[id]
     
+    def spin(self, text='*'):
+        """
+        var el = document.body.children[0];
+        window.el = el;
+        if (el && el.classList.contains("flx-spinner")) {
+            if (text === null) {
+                el.style.display = 'none';  // Stop the spinner
+            } else {
+                el.children[0].innerHTML += text.replace(/\*/g, '&#9632');
+            }
+        }
+        """
+    
     def initSocket(self):
         """ Make the connection to Python.
         """
@@ -201,6 +214,8 @@ class Flexx:
         """
         if msg.startswith('PING '):
             self.ws.send('PONG ' + msg[5:])
+        elif msg == 'INIT-DONE':
+            self.spin(None)
         elif msg.startswith('PRINT '):
             window.console.ori_log(msg[6:])
         elif msg.startswith('EVAL '):

--- a/flexx/app/session.py
+++ b/flexx/app/session.py
@@ -298,6 +298,7 @@ class Session(SessionAssets):
         # Send pending commands
         for command in self._pending_commands:
             self._ws.command(command)
+        self._ws.command('INIT-DONE')
    
     def _set_app(self, model):
         if self._model is not None:


### PR DESCRIPTION
This shows a simple "spinner" during startup. It gets displayed very quickly during page load, so that when startup takes a bit longer, you know that it at least is doing something. It shows a kind of progress bar that consists of small squares, one for each module being loaded.

Startup time consists of two parts: loading the assets, instantiating the models. The Flexx server sends a special command right after emptying its queue of pending commands into the websocket, which tells the client that initialization is done and that the spinner can be hidden.