### PR TITLE
Ensure app url ends with slash

### DIFF
--- a/flexx/app/funcs.py
+++ b/flexx/app/funcs.py
@@ -252,7 +252,7 @@ class App:
                                'yet running.')
         else:
             host, port = _current_server.serving
-            return 'http://%s:%i/%s' % (host, port, self._path)
+            return 'http://%s:%i/%s/' % (host, port, self._path)
     
     @property
     def name(self):

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -293,7 +293,9 @@ class AppHandler(FlexxHandler):
         app_name = app_name or '__main__'
         if app_name == '__main__':
             app_name = manager.has_app_name('__main__')
-            
+        elif not '/' in full_path:
+            return self.redirect('/%s/' % app_name)  # ensure slash behind name
+        
         # Maybe the user wants an index? Otherwise error.
         if not app_name:
             if not parts:

--- a/flexx/app/tornadoserver.py
+++ b/flexx/app/tornadoserver.py
@@ -293,7 +293,7 @@ class AppHandler(FlexxHandler):
         app_name = app_name or '__main__'
         if app_name == '__main__':
             app_name = manager.has_app_name('__main__')
-        elif not '/' in full_path:
+        elif '/' not in full_path:
             return self.redirect('/%s/' % app_name)  # ensure slash behind name
         
         # Maybe the user wants an index? Otherwise error.


### PR DESCRIPTION
Fix for a problem introduced in #277 (or slightly before that?). The server did redirect urls to apps if needed, but that code was lost in a refactoring. This brings it back.