### PR TITLE
Raise error when trying to use "*" in connection string inproperly.

### DIFF
--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -383,5 +383,8 @@ class Handler:
             for sub_ob in ob:
                 self._seek_event_object(index, path, sub_ob)
             return
-        
-        return self._seek_event_object(index, path, ob)
+        elif selector == '*':  # "**" is recursive, so allow more
+            t = 'Invalid connection "%s" because %s is not a tuple/list.'
+            raise RuntimeError(t % (obname_full, obname))
+        else:
+            return self._seek_event_object(index, path, ob)

--- a/flexx/event/tests/test_handlers.py
+++ b/flexx/event/tests/test_handlers.py
@@ -347,7 +347,7 @@ def test_connecting_and_getting_cached_event():
     assert len(res) == 1
 
 
-def test_exceptions():
+def test_exceptions1():
     h = event.HasEvents()
     
     @h.connect('foo')
@@ -370,6 +370,29 @@ def test_exceptions():
     # Its different for a direct call
     with raises(ZeroDivisionError):
         handle_foo()
+
+
+def test_exceptions2():
+    
+    class Foo(event.HasEvents):
+        def __init__(self):
+            super().__init__()
+            self.bar = event.HasEvents()
+            self.bars = [self.bar]
+    
+    f = Foo()
+    
+    # ok
+    @f.connect('bars.*.spam')
+    def handle_foo(*events):
+        pass
+    
+    # not ok
+    with raises(RuntimeError) as err:
+        @f.connect('bar.*.spam')
+        def handle_foo(*events):
+            pass
+    assert 'not a tuple' in str(err)
 
 
 def test_dispose1():

--- a/flexx/util/testing.py
+++ b/flexx/util/testing.py
@@ -62,9 +62,8 @@ def run_tests_if_main(show_coverage=False):
     fname = str(local_vars['__file__'])
     _clear_our_modules()
     _enable_faulthandler()
-    pytest.main('-v -x --color=yes --cov %s '
-                '--cov-config .coveragerc --cov-report html %s' %
-                (PACKAGE_NAME, repr(fname)))
+    pytest.main(['-v', '-x', '--color=yes', '--cov', PACKAGE_NAME,
+                 '--cov-config', '.coveragerc', '--cov-report', 'html', fname])
     if show_coverage:
         import webbrowser
         fname = os.path.join(ROOT_DIR, 'htmlcov', 'index.html')

--- a/make/test.py
+++ b/make/test.py
@@ -50,10 +50,9 @@ def test_unit(rel_path='.'):
         assert ROOT_DIR in os.path.abspath(m.__path__[0])
     # Start tests
     _enable_faulthandler()
-    cov_report = '--cov-report=term --cov-report=html'
     try:
-        res = pytest.main('--cov %s --cov-config=.coveragerc %s %r' % 
-                          (NAME, cov_report, test_path))
+        res = pytest.main(['--cov', NAME, '--cov-config=.coveragerc',
+                           '--cov-report=term', '--cov-report=html', test_path])
         sys.exit(res)
     finally:
         m = __import__(NAME)


### PR DESCRIPTION
And fix how we call `pytest.main()`.