### PR TITLE
All modules implicitly depend on flexx.app.clientcore

### DIFF
--- a/flexx/app/asset.py
+++ b/flexx/app/asset.py
@@ -231,6 +231,8 @@ class Bundle(Asset):
         bundles, so that bundles themselves can be sorted.
         """
         
+        ext = '.' + self.name.rsplit('.')[-1].lower()
+        
         # Check if module belongs here
         if not m.name.startswith(self._module_name):
             raise ValueError('Module %s does not belong in bundle %s.' %
@@ -241,15 +243,18 @@ class Bundle(Asset):
         self._need_sort = True
         
         # Add deps for this module
+        # Add implicit dependency of core Flexx functionality, like serializer, etc.
         deps = set()
-        for dep in m.deps:
+        module_deps = m.deps
+        if ext == '.js':
+            module_deps.add('flexx.app.clientcore')
+        for dep in module_deps:
             while '.' in dep:
                 deps.add(dep)
                 dep = dep.rsplit('.', 1)[0]
             deps.add(dep)
         
         # Clear deps that are represented by this bundle
-        ext = '.' + self.name.rsplit('.')[-1]
         for dep in deps:
             if not (dep.startswith(self._module_name) or
                     self._module_name.startswith(dep + '.')):

--- a/flexx/app/modules.py
+++ b/flexx/app/modules.py
@@ -148,7 +148,11 @@ class JSModule:
     def deps(self):
         """ The set of dependencies (names of other modules) for this module.
         """
-        return set(self._deps.keys())
+        # Add implicit dependency of core Flexx functionality, like
+        # serializer, etc.
+        s = set(self._deps.keys())
+        s.add('flexx.app.clientcore')
+        return s
     
     @property
     def changed_time(self):

--- a/flexx/app/modules.py
+++ b/flexx/app/modules.py
@@ -148,11 +148,7 @@ class JSModule:
     def deps(self):
         """ The set of dependencies (names of other modules) for this module.
         """
-        # Add implicit dependency of core Flexx functionality, like
-        # serializer, etc.
-        s = set(self._deps.keys())
-        s.add('flexx.app.clientcore')
-        return s
+        return set(self._deps.keys())
     
     @property
     def changed_time(self):

--- a/flexx/app/tests/test_asset.py
+++ b/flexx/app/tests/test_asset.py
@@ -212,6 +212,7 @@ def test_bundle():
     assert bundle.modules == (m3, m1, m2)
     
     # Deps are agregated
+    assert 'flexx.app.clientcore.js' in bundle.deps
     assert 'flexx.app.js' in bundle.deps
     assert 'flexx.app.model.js' in bundle.deps
     assert not any('flexx.ui' in dep for dep in bundle.deps)


### PR DESCRIPTION
Modules might need core Flexx stuff. But more importantly, the asset uses `flexx.spin`.