### PR TITLE
Allow running Phosphor provided by Jupyter

### DIFF
--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -101,7 +101,7 @@ function require (name) {
             if (!path.endsWith('.js')) { path = path + '.js'; }
             return window.jupyter.require(path);
         } else {
-            return window.require_phosphor(name);
+            return window.require_phosphor(name);  // provided by our Phosphor-all
         }
     }
     if (modules[name] === undefined) {

--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -95,6 +95,12 @@ define.amd = true;
 define.flexx = true;
 
 function require (name) {
+    if (name.startsWith('phosphor/')) {
+        return window.require_phosphor(name);
+    }
+    if (modules[name] === undefined) {
+        throw Error('Unknown module: ' + name);
+    }
     return modules[name];
 }
 

--- a/flexx/app/assetstore.py
+++ b/flexx/app/assetstore.py
@@ -96,7 +96,13 @@ define.flexx = true;
 
 function require (name) {
     if (name.startsWith('phosphor/')) {
-        return window.require_phosphor(name);
+        if (window.jupyter && window.jupyter.require) {
+            var path = 'phosphor@*/' + name.slice(9);
+            if (!path.endsWith('.js')) { path = path + '.js'; }
+            return window.jupyter.require(path);
+        } else {
+            return window.require_phosphor(name);
+        }
     }
     if (modules[name] === undefined) {
         throw Error('Unknown module: ' + name);

--- a/flexx/app/modules.py
+++ b/flexx/app/modules.py
@@ -17,7 +17,11 @@ from . import logger
 
 
 pyscript_types = type, types.FunctionType  # class or function
-json_types = None.__class__, bool, int, float, str, tuple, list, dict
+
+if sys.version_info > (3, ):
+    json_types = None.__class__, bool, int, float, str, tuple, list, dict
+else:
+    json_types = None.__class__, bool, int, float, basestring, tuple, list, dict  # noqa, bah
 
 # In essense, the idea of modules is all about propagating dependencies:
 # 

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -458,8 +458,8 @@ class Widget(Model):
         def __container_changed(self, *events):
             id = events[-1].new_value
             self.outernode.classList.remove('flx-main-widget')
-            if self.parent:
-                return
+            if self.parent or self.phosphor.parent:
+                return  # e.g. embedded in a larger phosphor app
             # Detach
             if self.phosphor.isAttached:
                 try:

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -11,7 +11,7 @@
 
 from .. import event, app
 from ..app import Model, get_active_model
-from ..pyscript import undefined, window
+from ..pyscript import undefined, window, RawJS
 from ..util.getresource import get_resource
 
 
@@ -19,6 +19,11 @@ from ..util.getresource import get_resource
 for asset_name in ('phosphor-all.css', 'phosphor-all.js'):
     code = get_resource(asset_name).decode()
     app.assets.associate_asset(__name__, asset_name, code)
+
+
+_phosphor_panel = RawJS("flexx.require('phosphor/lib/ui/panel')")
+_phosphor_widget = RawJS("flexx.require('phosphor/lib/ui/widget')")
+_phosphor_messaging = RawJS("flexx.require('phosphor/lib/core/messaging')")
 
 
 # To give both JS and Py a parent property without having it synced,
@@ -297,14 +302,16 @@ class Widget(Model):
                     pass  # not sure what close means in Phosphor
                 elif msg.type == 'child-added':
                     if msg.child.id not in window.flexx.instances:
-                        print('Phosphor child added that is not managed by Flexx.')
+                        if not msg.child.node.classList.contains('p-TabBar'):
+                            print('Phosphor child %r added to %r that is not '
+                                'managed by Flexx.' % (msg.child.id, self.id))
                     elif window.flexx.instances[msg.child.id] not in self.children:
                         print('Phosphor child %s added without Flexx knowing' %
                               msg.child.id)
                 elif msg.type == 'child-removed':
                     pass
                 return True  # resume processing the message as normal
-            window.phosphor.core.messaging.installMessageHook(self.phosphor, msg_hook)
+            _phosphor_messaging.installMessageHook(self.phosphor, msg_hook)
             
             # Keep track of Phosphor changing the title
             def _title_changed_in_phosphor(title):
@@ -327,14 +334,14 @@ class Widget(Model):
         def _init_phosphor_and_node(self):
             """ Overload this in sub widgets.
             """
-            self.phosphor = window.phosphor.ui.panel.Panel()
+            self.phosphor = _phosphor_panel.Panel()
             self.node = self.phosphor.node
         
         def _create_phosphor_widget(self, element_name='div'):
             """ Convenience func to create a Phosphor widget from a div element name.
             """
             node = window.document.createElement(element_name)
-            return window.phosphor.ui.widget.Widget({'node': node})
+            return _phosphor_widget.Widget({'node': node})
         
         @event.connect('style')
         def __style_changed(self, *events):
@@ -456,7 +463,7 @@ class Widget(Model):
             # Detach
             if self.phosphor.isAttached:
                 try:
-                    window.phosphor.ui.widget.Widget.detach(self.phosphor)
+                    _phosphor_widget.Widget.detach(self.phosphor)
                 except Exception as err:
                     err.message += ' (%s)' % self.id
                     raise err
@@ -469,7 +476,7 @@ class Widget(Model):
                 else:
                     el = window.document.getElementById(id)
                 try:
-                    window.phosphor.ui.widget.Widget.attach(self.phosphor, el)
+                    _phosphor_widget.Widget.attach(self.phosphor, el)
                 except Exception as err:
                     err.message += ' (%s)' % self.id
                     raise err

--- a/flexx/ui/layouts/_box.py
+++ b/flexx/ui/layouts/_box.py
@@ -108,8 +108,11 @@ Interactive example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import RawJS
 from . import Layout
+
+
+_phosphor_boxpanel = RawJS("flexx.require('phosphor/lib/ui/boxpanel')")
 
 
 class BaseBoxLayout(Layout):
@@ -333,16 +336,15 @@ class BoxPanel(BaseBoxLayout):
         _DEFAULT_ORIENTATION = 'h'
         
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.boxpanel.BoxPanel()
+            self.phosphor = _phosphor_boxpanel.BoxPanel()
             self.node = self.phosphor.node
         
         @event.connect('orientation', 'children', 'children.*.flex')
         def __set_flexes(self, *events):
             i = 0 if self.orientation in (0, 'h', 'hr') else 1
             for widget in self.children:
-                window.phosphor.ui.boxpanel.BoxPanel.setStretch(widget.phosphor,
-                                                                widget.flex[i])
-                window.phosphor.ui.boxpanel.BoxPanel.setSizeBasis(widget.phosphor, 100)
+                _phosphor_boxpanel.BoxPanel.setStretch(widget.phosphor, widget.flex[i])
+                _phosphor_boxpanel.BoxPanel.setSizeBasis(widget.phosphor, 100)
         
         @event.connect('spacing')
         def __spacing_changed(self, *events):

--- a/flexx/ui/layouts/_dock.py
+++ b/flexx/ui/layouts/_dock.py
@@ -18,8 +18,11 @@ Example:
 
 """
 
-from ...pyscript import window
+from ...pyscript import RawJS
 from . import Layout
+
+
+_phosphor_dockpanel = RawJS("flexx.require('phosphor/lib/ui/dockpanel')")
 
 
 class DockPanel(Layout):
@@ -38,7 +41,7 @@ class DockPanel(Layout):
     class JS:
         
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.dockpanel.DockPanel()
+            self.phosphor = _phosphor_dockpanel.DockPanel()
             self.node = self.phosphor.node
         
         def _add_child(self, widget):

--- a/flexx/ui/layouts/_grid.py
+++ b/flexx/ui/layouts/_grid.py
@@ -36,9 +36,13 @@ The GridPanel is deprecated for the time being.
 """
 
 from ... import event
-from ...pyscript import window, Infinity
+from ...pyscript import Infinity, RawJS
 from . import Layout
 from ._form import BaseTableLayout
+
+
+_phosphor_gridpanel = "not packed atm"
+_phosphor_messaging = RawJS("flexx.require('phosphor/lib/core/messaging')")
 
 
 class GridPanel(Layout):
@@ -76,7 +80,7 @@ class GridPanel(Layout):
     class JS:
         
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.gridpanel.GridPanel()
+            self.phosphor = _phosphor_gridpanel.GridPanel()
             self.node = self.phosphor.node
             
             that = self  # todo: just use self ...
@@ -84,7 +88,7 @@ class GridPanel(Layout):
                 if msg._type == 'layout-request':
                     that._child_limits_changed()
                 return False
-            window.phosphor.core.messaging.installMessageHook(self.phosphor, msg_hook)
+            _phosphor_messaging.installMessageHook(self.phosphor, msg_hook)
         
         @event.connect('children', 'children.*.pos',
                        'children.*.flex', 'children.*.base_size')
@@ -96,8 +100,8 @@ class GridPanel(Layout):
             max_row, max_col = 0, 0
             for child in self.children:
                 x, y = child.pos
-                window.phosphor.ui.gridpanel.GridPanel.setColumn(child.phosphor, x)
-                window.phosphor.ui.gridpanel.GridPanel.setRow(child.phosphor, y)
+                _phosphor_gridpanel.GridPanel.setColumn(child.phosphor, x)
+                _phosphor_gridpanel.GridPanel.setRow(child.phosphor, y)
                 max_col = max(max_col, x)
                 max_row = max(max_row, y)
             
@@ -122,7 +126,7 @@ class GridPanel(Layout):
             # Assign
             self.phosphor._columnSpecs = colSpecs
             self.phosphor._rowSpecs = rowSpecs
-            Spec = window.phosphor.ui.gridpanel.Spec
+            Spec = _phosphor_gridpanel.Spec
             self.phosphor.columnSpecs = [Spec(i) for i in colSpecs]
             self.phosphor.rowSpecs = [Spec(i) for i in rowSpecs]
         

--- a/flexx/ui/layouts/_pinboard.py
+++ b/flexx/ui/layouts/_pinboard.py
@@ -16,8 +16,11 @@ Example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import RawJS
 from . import Layout
+
+
+_phosphor_panel = RawJS("flexx.require('phosphor/lib/ui/panel')")
 
 
 class PinboardLayout(Layout):
@@ -38,7 +41,7 @@ class PinboardLayout(Layout):
     
     class JS:
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.panel.Panel()
+            self.phosphor = _phosphor_panel.Panel()
             self.node = self.phosphor.node
         
         @event.connect('children', 'children.*.pos')

--- a/flexx/ui/layouts/_split.py
+++ b/flexx/ui/layouts/_split.py
@@ -20,8 +20,11 @@ Example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import RawJS
 from . import Layout
+
+
+_phosphor_splitpanel = RawJS("flexx.require('phosphor/lib/ui/splitpanel')")
 
 
 class SplitPanel(Layout):
@@ -56,7 +59,7 @@ class SplitPanel(Layout):
         _DEFAULT_ORIENTATION = 'h'
         
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.splitpanel.SplitPanel()
+            self.phosphor = _phosphor_splitpanel.SplitPanel()
             self.node = self.phosphor.node
         
         @event.connect('orientation')

--- a/flexx/ui/layouts/_stack.py
+++ b/flexx/ui/layouts/_stack.py
@@ -27,8 +27,12 @@ Example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import RawJS
 from . import Widget, Layout
+
+
+_phosphor_stackedpanel = RawJS("flexx.require('phosphor/lib/ui/stackedpanel')")
+_phosphor_iteration = RawJS("flexx.require('phosphor/lib/algorithm/iteration')")
 
 
 class StackedPanel(Layout):
@@ -48,13 +52,12 @@ class StackedPanel(Layout):
     class JS:
         
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.stackedpanel.StackedPanel()
+            self.phosphor = _phosphor_stackedpanel.StackedPanel()
             self.node = self.phosphor.node
         
         @event.connect('current')
         def __set_current_widget(self, *events):
             widget = events[-1].new_value
-            window.phosphor.algorithm.iteration.each(self.phosphor.widgets,
-                                                     lambda w: w.hide())
+            _phosphor_iteration.each(self.phosphor.widgets, lambda w: w.hide())
             if widget is not None:
                 widget.phosphor.show()

--- a/flexx/ui/layouts/_tabs.py
+++ b/flexx/ui/layouts/_tabs.py
@@ -29,8 +29,12 @@ Example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import window, RawJS
 from . import Layout, Widget
+
+
+#_phosphor_tabbar = RawJS("flexx.require('phosphor/lib/ui/tabbar')")
+_phosphor_tabpanel = RawJS("flexx.require('phosphor/lib/ui/tabpanel')")
 
 
 # class TabBar(Widget):
@@ -38,7 +42,7 @@ from . import Layout, Widget
 #     """
 #     
 #     def _init_phosphor_and_node(self):
-#         self.phosphor = window.phosphor.ui.tabbar.TabBar()
+#         self.phosphor = _phosphor_tabbar.TabBar()
 #         self.node = self.phosphor.node
 # 
 #     def _add_child(self, widget):
@@ -66,7 +70,7 @@ class TabPanel(Layout):
     class JS:
         
         def _init_phosphor_and_node(self):
-            self.phosphor = window.phosphor.ui.tabpanel.TabPanel()
+            self.phosphor = _phosphor_tabpanel.TabPanel()
             self.node = self.phosphor.node
             
             def _phosphor_changes_current(v, info):

--- a/flexx/ui/widgets/_group.py
+++ b/flexx/ui/widgets/_group.py
@@ -30,8 +30,11 @@ Interactive example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import window, RawJS
 from . import Widget
+
+
+_phosphor_panel = RawJS("flexx.require('phosphor/lib/ui/panel')")
 
 
 class GroupWidget(Widget):
@@ -45,7 +48,7 @@ class GroupWidget(Widget):
         
         def _init_phosphor_and_node(self):
             
-            self.phosphor = window.phosphor.ui.panel.Panel()
+            self.phosphor = _phosphor_panel.Panel()
             
             # Replace the internal node of the phosphor widget.
             # Bit of a hack, but I see no other way

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -30,8 +30,11 @@ Interactive example:
 """
 
 from ... import event
-from ...pyscript import window
+from ...pyscript import window, RawJS
 from . import Widget
+
+
+_phosphor_widget = RawJS("flexx.require('phosphor/lib/ui/widget')")
 
 
 class LineEdit(Widget):
@@ -80,7 +83,7 @@ class LineEdit(Widget):
             node = d.childNodes[0]
             
             # Wrap up in Phosphor
-            self.phosphor = window.phosphor.ui.widget.Widget({'node': node})
+            self.phosphor = _phosphor_widget.Widget({'node': node})
             self.node = self.phosphor.node
             
             self._autocomp = window.document.createElement('datalist')

--- a/flexx/util/getresource.py
+++ b/flexx/util/getresource.py
@@ -24,13 +24,10 @@ except ImportError:
 
 
 # Definition of remote resources, optionally versioned ('{}' in url becomes tag)
+phosphor_url = 'https://raw.githubusercontent.com/zoofIO/phosphor-all/{}/dist/'
 RESOURCES = {
-    'phosphor-all.js': (
-        'https://raw.githubusercontent.com/zoofIO/phosphor-all/{}/phosphor-all.js',
-        'e3a0e5193bd36'),
-    'phosphor-all.css': (
-        'https://raw.githubusercontent.com/zoofIO/phosphor-all/{}/phosphor-all.css',
-        'e3a0e5193bd36'),
+    'phosphor-all.js': (phosphor_url + 'phosphor-all.js', '94d59b003849f'),
+    'phosphor-all.css': (phosphor_url + 'phosphor-all.css', '94d59b003849f'),
 }
 
 


### PR DESCRIPTION
* Make use of lastest Phosphor-all, which has a new API that uses a `window.require_phosphor()` function.
* Flexx' module loader `window.flexx.define` + `window.flexx.require` detects when something `phosphor/...` is required, and calls `window.jupyter.require()` or `window.require_phosphor()`.
* All widget modules load needed phosphor modules using `window.flexx.require()` (made possible by `RawJS` #290).
