### PR TITLE
Models are register per session instead of globally

### DIFF
--- a/docs/app/api.rst
+++ b/docs/app/api.rst
@@ -27,8 +27,6 @@ Functions related to us Model classes as apps
 
 .. autofunction:: flexx.app.App
 
-.. autofunction:: flexx.app.get_instance_by_id
-
 .. autofunction:: flexx.app.get_model_classes
 
 .. autofunction:: flexx.app.get_active_model

--- a/flexx/app/__init__.py
+++ b/flexx/app/__init__.py
@@ -219,7 +219,7 @@ del logging
 from ._app import App, manager
 from ._asset import Asset, Bundle
 from ._model import Model, get_active_model, get_get_active_models
-from ._model import get_instance_by_id, get_model_classes
+from ._model import get_model_classes
 from ._funcs import run, start, stop
 from ._funcs import init_interactive, init_notebook, serve, launch, export
 from ._server import call_later, create_server, current_server
@@ -227,4 +227,8 @@ from ._session import Session
 from ._modules import JSModule
 from ._assetstore import assets
 from ._clientcore import serializer
-from . import _tornadoserver  # import excplicitly to help tools like cx_Freeze
+
+# Resolve cyclic dependencies, and explicit exports to help cx_Freeze
+from . import _tornadoserver
+from. import _model
+_model.manager = manager

--- a/flexx/app/tests/test_model.py
+++ b/flexx/app/tests/test_model.py
@@ -211,22 +211,6 @@ def test_no_duplicate_code():
     assert '.red.' in Foo4.JS.CODE
 
 
-def test_get_instance_by_id():
-    
-    # This test needs a default session
-    session = app.manager.get_default_session()
-    if session is None:
-        app.manager.create_default_session()
-    
-    m1 = Foo1()
-    m2 = Foo1()
-    
-    assert m1 is not m2
-    assert app.get_instance_by_id(m1.id) is m1
-    assert app.get_instance_by_id(m2.id) is m2
-    assert app.get_instance_by_id('blaaaa') is None
-
-
 def test_active_models():
     
     ioloop = app.create_server(port=0, new_loop=True).loop


### PR DESCRIPTION
This fixes a nasty bug that was introduced when the model id's were handed out per-session. This relates slightly to #272, we'd need to perform a similar trick on the client side in that case.
