### PR TITLE
add support for HTTPS protocol

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -7,4 +7,6 @@ config = Config('flexx', '~appdata/.flexx.cfg',
     webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
     ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
                          'it is closed.'),
+    ssl_certfile=('', str, 'cert file for https server.'),
+    ssl_keyfile=('', str, 'key file for https server.'),
     )

--- a/flexx/app/_app.py
+++ b/flexx/app/_app.py
@@ -91,8 +91,9 @@ class App:
             raise RuntimeError('Cannot determine app url if the server is not '
                                'yet running.')
         else:
+            proto = server.protocol
             host, port = server.serving
-            return 'http://%s:%i/%s/' % (host, port, self._path)
+            return '%s://%s:%i/%s/' % (proto, host, port, self._path)
     
     @property
     def name(self):

--- a/flexx/app/_clientcore.py
+++ b/flexx/app/_clientcore.py
@@ -123,10 +123,13 @@ class Flexx:
         
         # Construct ws url (for nodejs the location is set by the flexx nodejs runtime)
         if not self.ws_url:
+            proto = 'ws'
+            if window.location.protocol == 'https:':
+                proto = 'wss'
             address = window.location.hostname
             if window.location.port:
                 address += ':' + window.location.port
-            self.ws_url = 'ws://%s/flexx/ws/%s' % (address, self.app_name)
+            self.ws_url = '%s://%s/flexx/ws/%s' % (proto, address, self.app_name)
         
         # Open web socket in binary mode
         self.ws = ws = WebSocket(self.ws_url)

--- a/flexx/app/_funcs.py
+++ b/flexx/app/_funcs.py
@@ -93,9 +93,11 @@ def init_interactive(cls=None, runtime=None):
 
     # Launch web runtime, the server will wait for the connection
     server = current_server()
+    proto = server.protocol
     host, port = server.serving
-    url = '%s:%i/%s/?session_id=%s' % (host, port, session.app_name, session.id)
-    session._runtime = launch('http://' + url, runtime=runtime)
+    url = '%s://%s:%i/%s/?session_id=%s' % (proto, host, port, session.app_name,
+                                            session.id)
+    session._runtime = launch(url, runtime=runtime)
     
 
 class NoteBookHelper:

--- a/flexx/app/_server.py
+++ b/flexx/app/_server.py
@@ -176,3 +176,9 @@ class AbstractServer:
         Or None if the server is not serving (anymore).
         """
         return self._serving
+
+    @property
+    def protocol(self):
+        """ Get a string representing served protocol
+        """
+        raise NotImplementedError

--- a/flexx/app/_server.py
+++ b/flexx/app/_server.py
@@ -50,6 +50,8 @@ def create_server(host=None, port=None, new_loop=False, backend='tornado',
             app.serve(Example, 'Example')
             app.run()
 
+        Alternately, cert and key files can be provided through
+           ``ssl_certfile`` and ``ssl_keyfile`` configuration variables.
     """
     # Lazy load tornado, so that we can use anything we want there without
     # preventing other parts of flexx.app from using *this* module.

--- a/flexx/app/_server.py
+++ b/flexx/app/_server.py
@@ -11,7 +11,8 @@ from .. import config
 _current_server = None
 
 
-def create_server(host=None, port=None, new_loop=False, backend='tornado', **server_kwargs):
+def create_server(host=None, port=None, new_loop=False, backend='tornado',
+                  **server_kwargs):
     """
     Create a new server object. This is automatically called; users generally
     don't need this, unless they want to explicitly specify host/port,

--- a/flexx/app/_server.py
+++ b/flexx/app/_server.py
@@ -11,7 +11,7 @@ from .. import config
 _current_server = None
 
 
-def create_server(host=None, port=None, new_loop=False, backend='tornado'):
+def create_server(host=None, port=None, new_loop=False, backend='tornado', **server_kwargs):
     """
     Create a new server object. This is automatically called; users generally
     don't need this, unless they want to explicitly specify host/port,
@@ -33,6 +33,7 @@ def create_server(host=None, port=None, new_loop=False, backend='tornado'):
             which is made current when ``start()`` is called. If ``False``
             (default) will use the current IOLoop for this thread.
         backend (str): Stub argument; only Tornado is currently supported.
+        **server_kwargs: keyword arguments passed to the server constructor
     
     Returns:
         server: The server object, see ``current_server()``.
@@ -53,7 +54,7 @@ def create_server(host=None, port=None, new_loop=False, backend='tornado'):
     if _current_server:
         _current_server.close()
     # Start hosting
-    _current_server = TornadoServer(host, port, new_loop)
+    _current_server = TornadoServer(host, port, new_loop, **server_kwargs)
     assert isinstance(_current_server, AbstractServer)
     # Schedule pending calls
     _current_server.call_later(0, _loop.loop.iter)
@@ -120,10 +121,10 @@ class AbstractServer:
         port (int): the port to serve at. None or 0 mean to autoselect a port.
     """
     
-    def __init__(self, host, port):
+    def __init__(self, host, port, **kwargs):
         self._serving = None
         if host is not False:
-            self._open(host, port)
+            self._open(host, port, **kwargs)
             assert self._serving  # Check that subclass set private variable
         self._running = False
     
@@ -151,7 +152,7 @@ class AbstractServer:
         self._serving = None
         self._close()
     
-    def _open(self, host, port):
+    def _open(self, host, port, **kwargs):
         raise NotImplementedError()
     
     def _start(self):

--- a/flexx/app/_server.py
+++ b/flexx/app/_server.py
@@ -34,10 +34,22 @@ def create_server(host=None, port=None, new_loop=False, backend='tornado',
             which is made current when ``start()`` is called. If ``False``
             (default) will use the current IOLoop for this thread.
         backend (str): Stub argument; only Tornado is currently supported.
-        **server_kwargs: keyword arguments passed to the server constructor
+        **server_kwargs: keyword arguments passed to the server constructor.
     
     Returns:
         server: The server object, see ``current_server()``.
+
+    Examples:
+
+        Configuring the server to use HTTPS with Tornado server:
+    
+        .. code-block:: py
+        
+            app.create_server(ssl_options = {'certfile' : '/path/to/certfile',
+                                             'keyfile' : '/path/to/keyfile'})
+            app.serve(Example, 'Example')
+            app.run()
+
     """
     # Lazy load tornado, so that we can use anything we want there without
     # preventing other parts of flexx.app from using *this* module.

--- a/flexx/app/_server.py
+++ b/flexx/app/_server.py
@@ -38,20 +38,6 @@ def create_server(host=None, port=None, new_loop=False, backend='tornado',
     
     Returns:
         server: The server object, see ``current_server()``.
-
-    Examples:
-
-        Configuring the server to use HTTPS with Tornado server:
-    
-        .. code-block:: py
-        
-            app.create_server(ssl_options = {'certfile' : '/path/to/certfile',
-                                             'keyfile' : '/path/to/keyfile'})
-            app.serve(Example, 'Example')
-            app.run()
-
-        Alternately, cert and key files can be provided through
-           ``ssl_certfile`` and ``ssl_keyfile`` configuration variables.
     """
     # Lazy load tornado, so that we can use anything we want there without
     # preventing other parts of flexx.app from using *this* module.

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -66,7 +66,20 @@ class TornadoServer(AbstractServer):
     def _open(self, host, port, **kwargs):
         # Note: does not get called if host is False. That way we can 
         # run Flexx in e.g. JLab's application.
-        
+
+        # handle ssl, wether from configuration or given args
+        if 'ssl_certfile' in config and config.ssl_certfile:
+            if 'ssl_options' not in kwargs:
+                kwargs['ssl_options'] = {}
+            if 'certfile' not in kwargs['ssl_options']:
+                kwargs['ssl_options']['certfile'] = config.ssl_certfile
+
+        if 'ssl_keyfile' in config and config.ssl_keyfile:
+            if 'ssl_options' not in kwargs:
+                kwargs['ssl_options'] = {}
+            if 'keyfile' not in kwargs['ssl_options']:
+                kwargs['ssl_options']['keyfile'] = config.ssl_keyfile
+                
         # Create tornado application
         self._app = Application([(r"/flexx/ws/(.*)", WSHandler),
                                  (r"/flexx/(.*)", MainHandler),

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -68,13 +68,13 @@ class TornadoServer(AbstractServer):
         # run Flexx in e.g. JLab's application.
 
         # handle ssl, wether from configuration or given args
-        if 'ssl_certfile' in config and config.ssl_certfile:
+        if config.ssl_certfile:
             if 'ssl_options' not in kwargs:
                 kwargs['ssl_options'] = {}
             if 'certfile' not in kwargs['ssl_options']:
                 kwargs['ssl_options']['certfile'] = config.ssl_certfile
 
-        if 'ssl_keyfile' in config and config.ssl_keyfile:
+        if config.ssl_keyfile:
             if 'ssl_options' not in kwargs:
                 kwargs['ssl_options'] = {}
             if 'keyfile' not in kwargs['ssl_options']:

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -159,6 +159,13 @@ class TornadoServer(AbstractServer):
         """ The Tornado HttpServer object being used."""
         return self._server
 
+    @property
+    def protocol(self):
+        """ Get a string representing served protocol."""
+        if self._server.ssl_options is not None:
+            return 'https'
+
+        return 'http'
 
 def port_hash(name):
     """ Given a string, returns a port number between 49152 and 65535

--- a/flexx/app/examples/serve_ssl.py
+++ b/flexx/app/examples/serve_ssl.py
@@ -1,0 +1,32 @@
+"""
+Flexx can be configured to use SSL.
+
+This example first creates a self-signed certificate and then uses it to create
+a SSL enabled web server (through Tornado ssl_option argument).
+
+Application served through this server is loaded on the browser with 'https' protocol and its websocket is using 'wss'.
+"""
+
+from flexx import app, event, ui
+
+# generate self-signed certificate for this example
+import os
+
+CERTFILE = '/tmp/self-signed.crt'
+KEYFILE = '/tmp/self-signed.key'
+
+os.system('openssl req -x509 -nodes -days 1 -batch -newkey rsa:2048 '
+          '-keyout %s -out %s' % (KEYFILE, CERTFILE))
+
+# Some very secret Model
+class Example(ui.Widget):
+    def init(self):
+        ui.Button(text = 'Secret Button')
+
+# configure web server for SSL
+app.create_server(ssl_options = {'certfile' : CERTFILE,
+                                 'keyfile' : KEYFILE})
+
+# run application
+app.serve(Example, 'Example')
+app.run()

--- a/flexx/app/examples/serve_ssl.py
+++ b/flexx/app/examples/serve_ssl.py
@@ -8,7 +8,7 @@ Application served through this server is loaded on the browser with 'https'
 protocol and its websocket is using 'wss'.
 """
 
-from flexx import app, ui
+from flexx import app, ui, config
 
 # generate self-signed certificate for this example
 import os
@@ -19,15 +19,16 @@ KEYFILE = '/tmp/self-signed.key'
 os.system('openssl req -x509 -nodes -days 1 -batch -newkey rsa:2048 '
           '-keyout %s -out %s' % (KEYFILE, CERTFILE))
 
+# use the self-signed certificate as if specified in normal config
+config.ssl_certfile = CERTFILE
+config.ssl_keyfile = KEYFILE
+
+
 # Some very secret Model
 class Example(ui.Widget):
     def init(self):
         ui.Button(text='Secret Button')
 
-# configure web server for SSL
-app.create_server(ssl_options={'certfile' : CERTFILE,
-                               'keyfile' : KEYFILE})
-
 # run application
 app.serve(Example, 'Example')
-app.run()
+app.start()

--- a/flexx/app/examples/serve_ssl.py
+++ b/flexx/app/examples/serve_ssl.py
@@ -4,10 +4,11 @@ Flexx can be configured to use SSL.
 This example first creates a self-signed certificate and then uses it to create
 a SSL enabled web server (through Tornado ssl_option argument).
 
-Application served through this server is loaded on the browser with 'https' protocol and its websocket is using 'wss'.
+Application served through this server is loaded on the browser with 'https'
+protocol and its websocket is using 'wss'.
 """
 
-from flexx import app, event, ui
+from flexx import app, ui
 
 # generate self-signed certificate for this example
 import os
@@ -21,11 +22,11 @@ os.system('openssl req -x509 -nodes -days 1 -batch -newkey rsa:2048 '
 # Some very secret Model
 class Example(ui.Widget):
     def init(self):
-        ui.Button(text = 'Secret Button')
+        ui.Button(text='Secret Button')
 
 # configure web server for SSL
-app.create_server(ssl_options = {'certfile' : CERTFILE,
-                                 'keyfile' : KEYFILE})
+app.create_server(ssl_options={'certfile' : CERTFILE,
+                               'keyfile' : KEYFILE})
 
 # run application
 app.serve(Example, 'Example')


### PR DESCRIPTION
Proof of concept for #303
* Allows to pass arguments to `tornado.HTTPServer` constructor through `app.create_server`.
* support for HTTPS protocol

Enable SSL transport by calling :
```
args = {}
args['ssl_options'] = {'certfile' : 'path-to-crtfile', 'keyfile' : 'path-to-keyfile'}
app.create_server(**args)

app.serve(Example, 'Example')
app.run()
```
