### PR TITLE
Fixed string replace in events.

### DIFF
--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -384,7 +384,9 @@ class Handler:
                 self._seek_event_object(index, path, sub_ob)
             return
         elif selector == '*':  # "**" is recursive, so allow more
-            t = "Invalid connection {obname_full} because {obname} is not a tuple/list.";
-            raise RuntimeError(t.replace("{opname_full}", obname_full).replace("{opname}", obname))
+            t = "Invalid connection {obname_full} because {obname} \
+                is not a tuple/list."
+            raise RuntimeError(t.replace("{opname_full}", obname_full)
+                .replace("{opname}", obname))
         else:
             return self._seek_event_object(index, path, ob)

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -25,23 +25,23 @@ def looks_like_method(func):
     except (TypeError, IndexError):
         return False
 
-        
+
 # Decorator to wrap a function in a Handler object
 def connect(*connection_strings):
     """ Decorator to turn a method of HasEvents into an event
     :class:`Handler <flexx.event.Handler>`.
-    
+
     A method can be connected to multiple event types. Each connection
     string represents an event type to connect to. Read more about
     dynamism and labels for further information on the possibilities
     of connection strings.
-    
+
     To connect functions or methods to an event from another HasEvents
     object, use that object's
     :func:`HasEvents.connect()<flexx.event.HasEvents.connect>` method.
-    
+
     .. code-block:: py
-        
+
         class MyObject(event.HasEvents):
             @event.connect('first_name', 'last_name')
             def greet(self, *events):
@@ -50,16 +50,16 @@ def connect(*connection_strings):
     if (not connection_strings) or (len(connection_strings) == 1 and
                                     callable(connection_strings[0])):
         raise RuntimeError('Connect decorator needs one or more event strings.')
-    
+
     func = None
     if callable(connection_strings[0]):
         func = connection_strings[0]
         connection_strings = connection_strings[1:]
-    
+
     for s in connection_strings:
         if not (isinstance(s, str) and len(s) > 0):
             raise ValueError('Connection string must be nonempty strings.')
-    
+
     def _connect(func):
         if not callable(func):
             raise TypeError('connect() decorator requires a callable.')
@@ -67,7 +67,7 @@ def connect(*connection_strings):
             raise TypeError('connect() decorator requires a method '
                             '(first arg must be self).')
         return HandlerDescriptor(func, connection_strings)
-    
+
     if func is not None:
         return _connect(func)
     else:
@@ -76,14 +76,14 @@ def connect(*connection_strings):
 
 class HandlerDescriptor:
     """ Class descriptor for handlers.
-    
+
     Arguments:
         func (callable): function that handles the events.
         connection_strings (list): the strings that represent the connections.
         ob (HasEvents, optional): the HasEvents object to use a a basis for the
             connection. A weak reference to this object is stored.
     """
-    
+
     def __init__(self, func, connection_strings, ob=None):
         assert callable(func)  # HandlerDescriptor is not instantiated directly
         self._func = func
@@ -91,21 +91,21 @@ class HandlerDescriptor:
         self._ob = None if ob is None else weakref.ref(ob)
         self._connection_strings = connection_strings
         self.__doc__ = '*%s*: %s' % ('event handler', func.__doc__ or self._name)
-    
+
     def __repr__(self):
         t = '<%s %r(this should be a class attribute) at 0x%x>'
         return t % (self.__class__.__name__, self._name, id(self))
-        
+
     def __set__(self, obj, value):
         raise AttributeError('Cannot overwrite handler %r.' % self._name)
-    
+
     def __delete__(self, obj):
         raise AttributeError('Cannot delete handler %r.' % self._name)
-    
+
     def __get__(self, instance, owner):
         if instance is None:
             return self
-        
+
         private_name = '_' + self._name + '_handler'
         try:
             handler = getattr(instance, private_name)
@@ -113,14 +113,14 @@ class HandlerDescriptor:
             handler = Handler((self._func, instance), self._connection_strings,
                               instance if self._ob is None else self._ob())
             setattr(instance, private_name, handler)
-        
+
         # Make the handler use *our* func one time. In most situations
         # this is the same function that the handler has, but not when
         # using super(); i.e. this allows a handler to call the same
         # handler of its super class.
         handler._use_once(self._func)
         return handler
-    
+
     @property
     def local_connection_strings(self):
         """ List of connection strings that are local to the object.
@@ -132,28 +132,28 @@ class Handler:
     """ Wrapper around a function object to connect it to one or more events.
     This class should not be instantiated directly; use ``event.connect`` or
     ``HasEvents.connect`` instead.
-    
+
     Arguments:
         func (callable): function that handles the events.
         connection_strings (list): the strings that represent the connections.
         ob (HasEvents): the HasEvents object to use a a basis for the
             connection. A weak reference to this object is stored.
     """
-    
+
     _count = 0
-    
+
     def __init__(self, func, connection_strings, ob):
         Handler._count += 1
         self._id = 'h%i' % Handler._count  # to ensure a consistent event order
-        
+
         # Store objects using a weakref.
         # - ob1 is the HasEvents object of which the connect() method was called
         #   to create the handler. Connection strings are relative to this object.
         # - ob2 is the object to be passed to func (if it is a method). Is often
         #   the same as ob1, but not per see. Can be None.
         self._ob1 = weakref.ref(ob)
-        
-        # Get unbounded version of bound methods. 
+
+        # Get unbounded version of bound methods.
         self._ob2 = None  # if None, its regarded a regular function
         if isinstance(func, tuple):
             self._ob2 = weakref.ref(func[1])
@@ -162,16 +162,16 @@ class Handler:
             if getattr(func, '__func__', None) is not None:
                 self._ob2 = weakref.ref(func.__self__)
                 func = func.__func__
-        
+
         # Store func, name, and docstring (e.g. for sphinx docs)
         assert callable(func)
         self._func = func
         self._func_once = func
         self._name = func.__name__
         self.__doc__ = '*%s*: %s' % ('event handler', func.__doc__ or self._name)
-        
+
         self._init(connection_strings)
-    
+
     def _init(self, connection_strings):
         """ Init of this handler that is compatible with PyScript.
         """
@@ -183,26 +183,26 @@ class Handler:
             d.fullname = s
             d.type = s.split('.')[-1]
             d.objects = []
-        
+
         # Pending events for this handler
         self._scheduled_update = False
         self._pending = []  # pending events
-        
+
         # Connect
         for index in range(len(self._connections)):
             self._connect_to_event(index)
-    
+
     def __repr__(self):
         c = '+'.join([str(len(c.objects)) for c in self._connections])
         cname = self.__class__.__name__
         return '<%s %r with %s connections at 0x%x>' % (cname, self._name, c, id(self))
-    
+
     def get_name(self):
         """ Get the name of this handler, usually corresponding to the name
         of the function that this handler wraps.
         """
         return self._name
-    
+
     def get_connection_info(self):
         """ Get a list of tuples (name, connection_names), where
         connection_names is a list of type names (including label) for
@@ -210,12 +210,12 @@ class Handler:
         """
         return [(c.fullname, [u[1] for u in c.objects])
                 for c in self._connections]
-    
+
     ## Calling / handling
-    
+
     def _use_once(self, func):
         self._func_once = func
-    
+
     def __call__(self, *events):
         """ Call the handler function.
         """
@@ -231,7 +231,7 @@ class Handler:
             res = func(*events)
         self._func_once = self._func
         return res
-    
+
     def _add_pending_event(self, label, ev):
         """ Add an event object to be handled at the next event loop
         iteration. Called from HasEvents.emit().
@@ -245,11 +245,11 @@ class Handler:
             else:
                 loop.call_later(self._handle_now_callback)
         self._pending.append((label, ev))
-    
+
     def _handle_now_callback(self):
         self._scheduled_update = False
         self.handle_now()
-    
+
     def handle_now(self):
         """ Invoke a call to the handler function with all pending
         events. This is normally called in a next event loop iteration
@@ -281,7 +281,7 @@ class Handler:
                 else:
                     err.skip_tb = 2
                     logger.exception(err)
-    
+
     def _collect(self):
         """ Get list of events and reconnect-events from list of pending events.
         """
@@ -294,12 +294,12 @@ class Handler:
             else:
                 events.append(ev)
         return events, reconnect
-    
+
     ## Connecting
-    
+
     def dispose(self):
         """ Cleanup any references.
-        
+
         Disconnects all connections, and cancel all pending events.
         """
         if not this_is_js():
@@ -310,7 +310,7 @@ class Handler:
                 ob.disconnect(name, self)
         while len(self._pending):
             self._pending.pop()  # no list.clear on legacy py
-    
+
     def _clear_hasevents_refs(self, ob):
         """ Clear all references to the given HasEvents instance. This is
         called from a HasEvents' dispose() method. This handler remains
@@ -320,48 +320,48 @@ class Handler:
             for i in range(len(connection.objects)-1, -1, -1):
                 if connection.objects[i][0] is ob:
                     connection.objects.pop(i)
-        
+
         # Do not clear pending events. This handler is assumed to continue
         # working, and should thus handle its pending events at some point,
         # at which point it cannot hold any references to ob anymore.
-    
+
     def _connect_to_event(self, index):
         """ Connect one connection.
         """
         connection = self._connections[index]
-        
+
         # Disconnect
         while len(connection.objects):
             ob, name = connection.objects.pop(0)
             ob.disconnect(name, self)
-        
+
         path = connection.fullname.replace('.*', '*').split('.')[:-1]
-        
+
         # Obtain root object and setup connections
         ob = self._ob1()
         if ob is not None:
             self._seek_event_object(index, path, ob)
-        
+
         # Verify
         if not connection.objects:
             raise RuntimeError('Could not connect to %r' % connection.fullname)
-        
+
         # Connect
         for ob, type in connection.objects:
             ob._register_handler(type, self)
-    
+
     def _seek_event_object(self, index, path, ob):
         """ Seek an event object based on the name (PyScript compatible).
         """
         connection = self._connections[index]
-        
+
         # Done traversing name: add to list or fail
         if ob is None or not len(path):
             if ob is None or not hasattr(ob, '_IS_HASEVENTS'):
                 return  # we cannot seek further
             connection.objects.append((ob, connection.type))
             return  # found it
-        
+
         # Resolve name
         obname_full, path = path[0], path[1:]
         obname = obname_full.rstrip('*')
@@ -384,7 +384,7 @@ class Handler:
                 self._seek_event_object(index, path, sub_ob)
             return
         elif selector == '*':  # "**" is recursive, so allow more
-            t = 'Invalid connection "%s" because %s is not a tuple/list.'
-            raise RuntimeError(t % (obname_full, obname))
+            t = "Invalid connection {obname_full} because {obname} is not a tuple/list.";
+            raise RuntimeError(t.replace("{opname_full}", obname_full).replace("{opname}", obname))
         else:
             return self._seek_event_object(index, path, ob)


### PR DESCRIPTION
pscripted code read:

```
else if (_pyfunc_op_equals(selector, "*")) {
            t = "Invalid connection \"%s\" because %s is not a tuple/list.";
            err_3 = new Error('RuntimeError:' + (t % [obname_full, obname])); err_3.name = "RuntimeError"; throw err_3;
```

Which raised a NaN error on Chrome when trying to print this:
_"Invalid connection volumes* because volumes is not a tuple/list."_
It was instead doing this (in the js console):
```
t = "Invalid connection \"%s\" because %s is not a tuple/list."; # "Invalid connection "%s" because %s is not a tuple/list."
t % [obname_full, obname]  # returns NaN
```
This should fix this error.