### PR TITLE
SSL support for remotely running Jupyter notebooks

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -9,5 +9,6 @@ config = Config('flexx', '~appdata/.flexx.cfg',
                          'it is closed.'),
     ssl_certfile=('', str, 'cert file for https server.'),
     ssl_keyfile=('', str, 'key file for https server.'),
-    hosts_whitelist=('', str, 'Comma separated list of allowed <host>:<port> values to pass cross-origin checks.'),
+    hosts_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
+                              'values to pass cross-origin checks.'),
     )

--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -1,14 +1,14 @@
 from .util.config import Config
 
 config = Config('flexx', '~appdata/.flexx.cfg',
-    log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
-    hostname=('localhost', str, 'The default hostname to serve apps.'),
-    port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
-    webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
-    ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
+                log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
+                hostname=('localhost', str, 'The default hostname to serve apps.'),
+                port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
+                webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
+                ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
                          'it is closed.'),
-    ssl_certfile=('', str, 'cert file for https server.'),
-    ssl_keyfile=('', str, 'key file for https server.'),
-    hosts_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
+                ssl_certfile=('', str, 'cert file for https server.'),
+                ssl_keyfile=('', str, 'key file for https server.'),
+                host_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
                               'values to pass cross-origin checks.'),
-    )
+                )

--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -9,4 +9,5 @@ config = Config('flexx', '~appdata/.flexx.cfg',
                          'it is closed.'),
     ssl_certfile=('', str, 'cert file for https server.'),
     ssl_keyfile=('', str, 'key file for https server.'),
+    hosts_whitelist=('', str, 'Comma separated list of allowed <host>:<port> values to pass cross-origin checks.'),
     )

--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -1,14 +1,14 @@
 from .util.config import Config
 
 config = Config('flexx', '~appdata/.flexx.cfg',
-                log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
-                hostname=('localhost', str, 'The default hostname to serve apps.'),
-                port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
-                webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
-                ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
-                         'it is closed.'),
-                ssl_certfile=('', str, 'cert file for https server.'),
-                ssl_keyfile=('', str, 'key file for https server.'),
-                host_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
-                              'values to pass cross-origin checks.'),
-                )
+            log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
+            hostname=('localhost', str, 'The default hostname to serve apps.'),
+            port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
+            webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
+            ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
+                     'it is closed.'),
+            ssl_certfile=('', str, 'cert file for https server.'),
+            ssl_keyfile=('', str, 'key file for https server.'),
+            host_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
+                          'values to pass cross-origin checks.'),
+            )

--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -1,14 +1,14 @@
 from .util.config import Config
 
 config = Config('flexx', '~appdata/.flexx.cfg',
-            log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
-            hostname=('localhost', str, 'The default hostname to serve apps.'),
-            port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
-            webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
-            ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
-                     'it is closed.'),
-            ssl_certfile=('', str, 'cert file for https server.'),
-            ssl_keyfile=('', str, 'key file for https server.'),
-            host_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
-                          'values to pass cross-origin checks.'),
-            )
+        log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
+        hostname=('localhost', str, 'The default hostname to serve apps.'),
+        port=(0, int, 'The default port to serve apps. Zero means auto-select.'),
+        webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
+        ws_timeout=(20, int, 'If the websocket is idle for this amount of seconds, '
+                 'it is closed.'),
+        ssl_certfile=('', str, 'cert file for https server.'),
+        ssl_keyfile=('', str, 'key file for https server.'),
+        host_whitelist=('', str, 'Comma separated list of allowed <host>:<port> '
+                      'values to pass cross-origin checks.'),
+        )

--- a/flexx/app/_funcs.py
+++ b/flexx/app/_funcs.py
@@ -187,13 +187,9 @@ def init_notebook():
     # Install helper to make things work in exported notebooks
     NoteBookHelper(session)
     
-    # We set session_id and app_name in a way that it does not end up
-    # in exported notebook.
-    if config.ssl_certfile != '' or config.ssl_keyfile != '':
-        # Connect over SSL
-        url = 'wss://%s:%i/flexx/ws/%s' % (host, port, session.app_name)
-    else:
-        url = 'ws://%s:%i/flexx/ws/%s' % (host, port, session.app_name)
+    proto = 'wss' if server.protocol == 'https' else 'ws'
+    
+    url = '%s://%s:%i/flexx/ws/%s' % (proto, host, port, session.app_name)
 
     flexx_pre_init = """<script>window.flexx = {};
                                 window.flexx.app_name = "%s";

--- a/flexx/app/_funcs.py
+++ b/flexx/app/_funcs.py
@@ -189,7 +189,12 @@ def init_notebook():
     
     # We set session_id and app_name in a way that it does not end up
     # in exported notebook.
-    url = 'ws://%s:%i/flexx/ws/%s' % (host, port, session.app_name)
+    if config.ssl_certfile != '' or config.ssl_keyfile != '':
+        # Connect over SSL
+        url = 'wss://%s:%i/flexx/ws/%s' % (host, port, session.app_name)
+    else:
+        url = 'ws://%s:%i/flexx/ws/%s' % (host, port, session.app_name)
+
     flexx_pre_init = """<script>window.flexx = {};
                                 window.flexx.app_name = "%s";
                                 window.flexx.session_id = "%s";

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -676,9 +676,9 @@ class WSHandler(WebSocketHandler):
         #WebSocketHandler.check_origin
         
         serving_host = self.request.headers.get("Host")
-        serving_hostname = serving_host.split(':')[0]
-        connecting_host = urlparse(origin).netloc
-        connecting_hostname = connecting_host.split(':')[0]
+        serving_hostname = serving_host.split(':')[0].lower()
+        connecting_host = urlparse(origin).netloc.lower()
+
         
         if serving_hostname == 'localhost':
             return True  # Safe
@@ -686,9 +686,7 @@ class WSHandler(WebSocketHandler):
             return True  # we cannot know if the origin matches
         elif serving_host == connecting_host:
             return True
-        elif serving_hostname == connecting_hostname:
-            # Comparing hostnames in case of Jupyter notebooks
-            # connecting_host and serving_host have same host names but different ports
+        elif connecting_host in config.hosts_whitelist.lower():
             return True
         else:
             logger.info('Connection refused from %s' % origin)

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -678,12 +678,17 @@ class WSHandler(WebSocketHandler):
         serving_host = self.request.headers.get("Host")
         serving_hostname = serving_host.split(':')[0]
         connecting_host = urlparse(origin).netloc
+        connecting_hostname = connecting_host.split(':')[0]
         
         if serving_hostname == 'localhost':
             return True  # Safe
         elif serving_hostname == '0.0.0.0':
             return True  # we cannot know if the origin matches
         elif serving_host == connecting_host:
+            return True
+        elif serving_hostname == connecting_hostname:
+            # Comparing hostnames in case of Jupyter notebooks
+            # connecting_host and serving_host have same host names but different ports
             return True
         else:
             logger.info('Connection refused from %s' % origin)

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -676,8 +676,8 @@ class WSHandler(WebSocketHandler):
         #WebSocketHandler.check_origin
         
         serving_host = self.request.headers.get("Host")
-        serving_hostname = serving_host.split(':')[0].lower()
-        connecting_host = urlparse(origin).netloc.lower()
+        serving_hostname = serving_host.split(':')[0]
+        connecting_host = urlparse(origin).netloc
 
         
         if serving_hostname == 'localhost':
@@ -686,7 +686,7 @@ class WSHandler(WebSocketHandler):
             return True  # we cannot know if the origin matches
         elif serving_host == connecting_host:
             return True
-        elif connecting_host in config.hosts_whitelist.lower():
+        elif connecting_host in config.hosts_whitelist:
             return True
         else:
             logger.info('Connection refused from %s' % origin)

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -686,7 +686,7 @@ class WSHandler(WebSocketHandler):
             return True  # we cannot know if the origin matches
         elif serving_host == connecting_host:
             return True
-        elif connecting_host in config.hosts_whitelist:
+        elif connecting_host in config.host_whitelist:
             return True
         else:
             logger.info('Connection refused from %s' % origin)


### PR DESCRIPTION
* app.init_notebook() fix added WSS to url
* TornadoServer  Comparing hostnames in case of Jupyter notebooks connecting_host and serving_host have same host names but different ports