### PR TITLE
Add assetstore.remove_data()

### DIFF
--- a/flexx/app/_assetstore.py
+++ b/flexx/app/_assetstore.py
@@ -415,8 +415,12 @@ class AssetStore:
     def add_shared_data(self, name, data):
         """ Add data to serve to the client (e.g. images), which is shared
         between sessions. It is an error to add data with a name that is
-        already registered. See ``Session.add_data()`` to set data per-session
-        and `Model.send_data()`` to send data to Model objects directly.
+        already registered. The data remains available until it is removed via
+        ``remove_data()`` or until the server stops.
+        
+        Consider using `Model.send_data()`` to send data to the JS side
+        of a Model object directly, or ``Session.add_data()`` to set
+        per-session data that is released when the session is closed.
         
         Parameters:
             name (str): the name of the data, e.g. 'icon.png'. 
@@ -434,6 +438,16 @@ class AssetStore:
             raise TypeError('add_shared_data() data must be bytes.')
         self._data[name] = data
         return '_data/shared/%s' % name  # relative path so it works /w export
+    
+    def remove_data(self, name):
+        """ Remove the data with the given name. Use this function with
+        care; the specified data will become inaccessible for all apps served
+        from this process.
+        
+        Parameters:
+            name (str): name that was used to add the data.
+        """
+        self._data.pop(name, None)
     
     def export(self, dirname, clear=False):
         """ Write all shared data and used assets to the given directory.

--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -266,8 +266,8 @@ class Session:
     
     def remove_data(self, name):
         """ Remove the data associated with the given name. If you need this,
-        also consider ``send_data()``. Also note that data is automatically
-        released when the session is closed.
+        also consider ``send_data()``. Also note that all session data is
+        automatically released when the session is closed.
         """
         self._data.pop(name, None)
     

--- a/flexx/app/tests/test_assetstore.py
+++ b/flexx/app/tests/test_assetstore.py
@@ -115,6 +115,10 @@ def test_asset_store_data():
     with raises(ValueError):
         s.add_shared_data('xx', b'zzzz')
     
+    # Remove data
+    s.remove_data('xx')
+    assert s.get_data('xx') is None
+    
     # # Add url data
     # s.add_shared_data('readme', 'https://github.com/zoofIO/flexx/blob/master/README.md')
     # # assert 'Flexx is' in s.get_data('readme').decode()


### PR DESCRIPTION
A possible risk of adding this function is that it becomes easier to abuse the asset store as an in-memory static file server of sorts. Is that bad? Probably not for small-scale things, but in production its likely a bad idea.