### PR TITLE
add disabled property to LineEdit

### DIFF
--- a/flexx/ui/widgets/_color.py
+++ b/flexx/ui/widgets/_color.py
@@ -40,7 +40,13 @@ class ColorSelectWidget(Widget):
                 raise ValueError('%s.color must be in #rrggbb format, not %r' %
                                  (self.id, v))
             return str(v)
-    
+
+        @event.prop
+        def disabled(self, v=False):
+            """ Whether the color select is disabled.
+            """
+            return bool(v)
+
     class JS:
     
         def _init_phosphor_and_node(self):
@@ -55,3 +61,10 @@ class ColorSelectWidget(Widget):
         
         def _color_changed_from_dom(self, e):
             self.color = self.node.value
+
+        @event.connect('disabled')
+        def __disabled_changed(self, *events):
+            if events[-1].new_value:
+                self.node.setAttribute("disabled", "disabled")
+            else:
+                self.node.removeAttribute("disabled")

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -72,7 +72,13 @@ class LineEdit(Widget):
             in all browsers.
             """
             return tuple([str(i) for i in v])
-        
+
+        @event.prop
+        def disabled(self, v=False):
+            """ Whether the line edit is disabled.
+            """
+            return bool(v)
+
     class JS:
     
         def _init_phosphor_and_node(self):
@@ -135,3 +141,10 @@ class LineEdit(Widget):
                 op = window.document.createElement('option')
                 op.value = option
                 self._autocomp.appendChild(op)
+
+        @event.connect('disabled')
+        def __disabled_changed(self, *events):
+            if events[-1].new_value:
+                self.node.setAttribute("disabled", "disabled")
+            else:
+                self.node.removeAttribute("disabled")

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -60,7 +60,13 @@ class Slider(Widget):
         def value(self, v=0):
             """ The current slider value (settable)."""
             return float(min(self.max, max(self.min, v)))
-    
+
+        @event.prop
+        def disabled(self, v=False):
+            """ Whether the slider is disabled.
+            """
+            return bool(v)
+
     class JS:
         
         def _init_phosphor_and_node(self):
@@ -95,3 +101,10 @@ class Slider(Widget):
         @event.connect('max')
         def __max_changed(self, *events):
             self.node.max = events[-1].new_value
+
+        @event.connect('disabled')
+        def __disabled_changed(self, *events):
+            if events[-1].new_value:
+                self.node.setAttribute("disabled", "disabled")
+            else:
+                self.node.removeAttribute("disabled")


### PR DESCRIPTION
Copying #314 code to LineEdit widget.

This could probably apply to all widgets based on a `<input>` tag.

Can we just do the same for BaseDropDown widget?