### PR TITLE
make CodeMirror example more impressive

### DIFF
--- a/flexx/pyscript/parser3.py
+++ b/flexx/pyscript/parser3.py
@@ -172,10 +172,10 @@ Using JS specific functionality
 When writing PyScript inside Python modules, we recommend that where
 specific JavaScript functionality is used, that the references are
 prefixed with ``window.`` Where ``window`` represents the global JS 
-namespace to prefix JS objects. ``window`` will simply be removed
-by the transpiler. This helps make it clear that the functionality 
-is specific to JS, and also helps static code analysis tools like 
-flake8.
+namespace. All global JavaScript objects, functions, and variables
+automatically become members of the ``window`` object. This helps
+make it clear that the functionality is specific to JS, and also
+helps static code analysis tools like flake8.
 
 .. pyscript_example::
     

--- a/flexx/pyscript/parser3.py
+++ b/flexx/pyscript/parser3.py
@@ -166,14 +166,16 @@ Str methods
     "foobar".upper()
 
 
-Using JS specicic functionality
+Using JS specific functionality
 -------------------------------
 
 When writing PyScript inside Python modules, we recommend that where
 specific JavaScript functionality is used, that the references are
-prefixed with ``window.``. This helps make it clear that the
-functionality is specific to JS, and also helps static code analysis
-tools like flake8.
+prefixed with ``window.`` Where ``window`` represents the global JS 
+namespace to prefix JS objects. ``window`` will simply be removed
+by the transpiler. This helps make it clear that the functionality 
+is specific to JS, and also helps static code analysis tools like 
+flake8.
 
 .. pyscript_example::
     

--- a/flexx/ui/examples/code_editor.py
+++ b/flexx/ui/examples/code_editor.py
@@ -6,7 +6,7 @@ This example demonstrates a code editor widget based on CodeMirror.
 # todo: Maybe this should be a widget in the library (flexx.ui.CodeMirror) ?
 
 from flexx import ui, app, event
-from flexx.pyscript.stubs import window
+from flexx.pyscript import window
 
 # Associate CodeMirror's assets with this module so that Flexx will load
 # them when (things from) this module is used.

--- a/flexx/ui/examples/code_editor.py
+++ b/flexx/ui/examples/code_editor.py
@@ -8,13 +8,15 @@ This example demonstrates a code editor widget based on CodeMirror.
 from flexx import ui, app, event
 from flexx.pyscript.stubs import window
 
-
 # Associate CodeMirror's assets with this module so that Flexx will load
 # them when (things from) this module is used.
 base_url = 'https://cdnjs.cloudflare.com/ajax/libs/codemirror/'
 app.assets.associate_asset(__name__, base_url + '5.21.0/codemirror.min.css')
 app.assets.associate_asset(__name__, base_url + '5.21.0/codemirror.min.js')
-
+app.assets.associate_asset(__name__, base_url + '5.21.0/mode/python/python.js')
+app.assets.associate_asset(__name__, base_url + '5.21.0/theme/solarized.css')
+app.assets.associate_asset(__name__, base_url + '5.21.0/addon/selection/active-line.js')
+app.assets.associate_asset(__name__, base_url + '5.21.0/addon/edit/matchbrackets.js')
 
 class CodeEditor(ui.Widget):
     """ A CodeEditor widget based on CodeMirror.
@@ -31,9 +33,12 @@ class CodeEditor(ui.Widget):
         
         def init(self):
             # https://codemirror.net/doc/manual.html
-            options = dict(value='type code here ...',
+            options = dict(value='from flexx import ui, app, event',
                            mode='python',
-                           theme='default',
+                           theme='solarized dark',
+                           autofocus=True,
+                           styleActiveLine=True,
+                           matchBrackets=True,
                            indentUnit=4,
                            smartIndent=True,
                            lineWrapping=True,

--- a/flexx/ui/examples/code_editor_ace.py
+++ b/flexx/ui/examples/code_editor_ace.py
@@ -1,0 +1,44 @@
+# doc-export: CodeEditor
+"""
+This example demonstrates a code editor widget based on Ace.
+"""
+
+# todo: Maybe this should be a widget in the library (flexx.ui.Ace) ?
+
+from flexx import ui, app, event
+from flexx.pyscript import window
+
+# Associate Ace's assets with this module so that Flexx will load
+# them when (things from) this module is used.
+base_url = 'https://cdnjs.cloudflare.com/ajax/libs/ace/1.2.6/'
+app.assets.associate_asset(__name__, base_url + 'ace.js')
+app.assets.associate_asset(__name__, base_url + 'mode-python.js')
+app.assets.associate_asset(__name__, base_url + 'theme-solarized_dark.js')
+
+class CodeEditor(ui.Widget):
+    """ A CodeEditor widget based on Ace.
+    """
+    
+    CSS = """
+    .flx-CodeEditor > .ace {
+        width: 100%;
+        height: 100%;
+    }
+    """
+    
+    class JS:
+        def init(self):
+            # https://ace.c9.io/#nav=api
+            self.ace = window.ace.edit(self.node, "editor")
+            self.ace.setValue("import os\n\ndirs = os.walk")
+            self.ace.navigateFileEnd()  # otherwise all lines highlighted
+            self.ace.setTheme("ace/theme/solarized_dark")
+            self.ace.getSession().setMode("ace/mode/python")
+            
+        @event.connect('size')
+        def __on_size(self, *events):
+            self.ace.resize()
+
+if __name__ == '__main__':
+    app.launch(CodeEditor, 'xul')
+    app.run()

--- a/flexx/ui/examples/code_editor_cm.py
+++ b/flexx/ui/examples/code_editor_cm.py
@@ -33,7 +33,7 @@ class CodeEditor(ui.Widget):
         
         def init(self):
             # https://codemirror.net/doc/manual.html
-            options = dict(value='from flexx import ui, app, event',
+            options = dict(value='import os\n\ndirs = os.walk',
                            mode='python',
                            theme='solarized dark',
                            autofocus=True,

--- a/flexx/ui/examples/code_editor_cm.py
+++ b/flexx/ui/examples/code_editor_cm.py
@@ -1,4 +1,4 @@
-# doc-export: CodeEditor
+# doc-export: CodeEditor_CodeMirror
 """
 This example demonstrates a code editor widget based on CodeMirror.
 """

--- a/flexx/ui/examples/code_editor_cm.py
+++ b/flexx/ui/examples/code_editor_cm.py
@@ -1,4 +1,4 @@
-# doc-export: CodeEditor_CodeMirror
+# doc-export: CodeEditor
 """
 This example demonstrates a code editor widget based on CodeMirror.
 """
@@ -30,7 +30,6 @@ class CodeEditor(ui.Widget):
     """
     
     class JS:
-        
         def init(self):
             # https://codemirror.net/doc/manual.html
             options = dict(value='import os\n\ndirs = os.walk',
@@ -51,7 +50,6 @@ class CodeEditor(ui.Widget):
         @event.connect('size')
         def __on_size(self, *events):
             self.cm.refresh()
-
 
 if __name__ == '__main__':
     app.launch(CodeEditor, 'xul')


### PR DESCRIPTION
This PR fixes the Python syntax not being highlighted.

It also makes the example a little more impressive by showing how easy it is to change themes and enable features.