### PR TITLE
Fix recursion bug for named functions

### DIFF
--- a/flexx/event/_hasevents.py
+++ b/flexx/event/_hasevents.py
@@ -152,8 +152,9 @@ class HasEvents(with_metaclass(HasEventsMeta, object)):
             dd = getattr(self.__class__, name)._defaults
             if dd:
                 self._set_prop(name, dd[0], True)
-        for name, value in property_values.items():
+        for name in sorted(property_values):  # sort for deterministic order
             if name in self.__properties__:
+                value = property_values[name]
                 setattr(self, name, value)  # should raise error whith readonly
             else:
                 cname = self.__class__.__name__

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -95,8 +95,10 @@ class HasEventsJS:
             if not (isinstance(s, str) and len(s)):
                 raise ValueError('Connection string must be nonempty strings.')
         
-        name = func.name[6:] if func.name.startswith('bound ') else func.name
-        return self.__create_Handler(func, name or 'anonymous', connection_strings)
+        # Get function name (Flexx sets __name__ on methods)
+        name = func.__name__ or func.name or 'anonymous'
+        name = name.split(' ')[-1].split('flx_')[-1]
+        return self.__create_Handler(func, name, connection_strings)
     
     def __create_PyProperty(self, name):
         self.__create_Property(name)

--- a/flexx/pyscript/functions.py
+++ b/flexx/pyscript/functions.py
@@ -143,8 +143,8 @@ def js_rename(jscode, cur_name, new_name):
     Returns:
         jscode (str): the modified JavaScript source code
     """
-    jscode = jscode.replace('function %s' % cur_name,
-                            'function %s' % (new_name.split('.')[-1]), 1)
+    jscode = jscode.replace('function flx_%s' % cur_name,
+                            'function flx_%s' % (new_name.split('.')[-1]), 1)
     jscode = jscode.replace('%s = function' % cur_name, 
                             '%s = function' % (new_name), 1)
     jscode = jscode.replace('%s.prototype' % cur_name, 

--- a/flexx/pyscript/stdlib.py
+++ b/flexx/pyscript/stdlib.py
@@ -133,6 +133,7 @@ FUNCTIONS['op_instantiate'] = """function (ob, args) { // nargs: 2
         if (Object[name] === undefined &&
             typeof ob[name] === 'function' && !ob[name].nobind) {
             ob[name] = ob[name].bind(ob);
+            ob[name].__name__ = name;
         }
     }
     if (ob.__init__) {

--- a/flexx/pyscript/tests/test_parser2.py
+++ b/flexx/pyscript/tests/test_parser2.py
@@ -297,7 +297,7 @@ class TestFunctions:
         lines = [line for line in code.split('\n') if line]
         
         assert len(lines) == 4  # only three lines + definition
-        assert lines[1] == 'func1 = function func1 () {'  # no args
+        assert lines[1] == 'func1 = function flx_func1 () {'  # no args
         assert lines[2].startswith('  ')  # indented
         assert lines[3] == '};'  # dedented
     
@@ -310,7 +310,7 @@ class TestFunctions:
         lines = [line for line in code.split('\n') if line]
         
         assert len(lines) == 4  # only three lines + definition
-        assert lines[1] == 'method1 = function method1 () {'  # no args, no self/this
+        assert lines[1] == 'method1 = function () {'  # no args, no self/this
         assert lines[2].startswith('  ')  # indented
         assert lines[3] == '};'  # dedented
     
@@ -322,7 +322,7 @@ class TestFunctions:
         code = py2js(func)
         lines = [line for line in code.split('\n') if line]
         
-        assert lines[1] == 'func = function func (foo, bar) {'
+        assert lines[1] == 'func = function (foo, bar) {'
         assert '2' in code
         
         assert evaljs(code + 'func(2)') == '0'
@@ -426,6 +426,18 @@ class TestFunctions:
         assert 'var x' in py2js(func1)
         assert 'var x' in py2js(func2)
         assert 'var x' in py2js(func3)
+    
+    def test_recursion(self=None):
+        
+        code = 'def f(i): i *= 2; return i if i > 10 else f(i)\n\n'
+        assert evalpy(code + 'f(1)') == '16'
+        
+        clscode = 'class G:\n  def __init__(self): self.i = 1\n\n'
+        code = clscode + '  def f(self): self.i *= 2; return self.i if self.i > 10 else self.f()\n\n'
+        assert evalpy(code + 'g = G(); g.f()') == '16'
+        
+        code = clscode + '  def f(self):\n    def h(): self.i *= 2; return self.i if self.i > 10 else h()\n\n'
+        assert evalpy(code + '    return h()\n\ng = G(); g.f()') == '16'
     
     def test_global(self):
         assert py2js('global foo;foo = 3').strip() == 'foo = 3;'


### PR DESCRIPTION
* Fixes a nasty bug that broke things for closures that were called recursively inside a method, and `self` was used inside it.
* Methods remain anonymous (but we set `__name__` on them). Other functions (that are not lambdas) are named functions, but prefixed with "flx_"  to prevent calling the unbound method from a bound function.
* Fixes #212 consistent order of setting properties.