### PR TITLE
Make XUL use an explicit profile dir

### DIFF
--- a/flexx/webruntime/__init__.py
+++ b/flexx/webruntime/__init__.py
@@ -22,7 +22,7 @@ del logging
 
 from .. import config
 
-from ._manage import RUNTIME_DIR
+from ._manage import RUNTIME_DIR, TEMP_APP_DIR
 from .common import BaseRuntime, DesktopRuntime  # noqa
 from .xul import FirefoxRuntime
 from .nodewebkit import NWRuntime

--- a/flexx/webruntime/common.py
+++ b/flexx/webruntime/common.py
@@ -134,7 +134,7 @@ class BaseRuntime:
             if self._proc.stdin:  # pragma: no cover
                 self._proc.stdin.close()
             self._proc.terminate()
-            timeout = time.time() + 0.25
+            timeout = time.time() + 0.2
             while time.time() < timeout:
                 time.sleep(0.02)
                 if self._proc.poll() is not None:

--- a/flexx/webruntime/nodewebkit.py
+++ b/flexx/webruntime/nodewebkit.py
@@ -187,7 +187,8 @@ class NWRuntime(DesktopRuntime):
         # inside the app_path, it gets automatically cleaned up.
         profile_dir = op.join(app_path, 'stub_profile')
         if not op.isdir(profile_dir):
-
+            os.mkdir(profile_dir)
+        
         self._kwargs['title'] = self._kwargs.get('title', 'NW.js runtime')
         
         # Get runtime exe
@@ -195,13 +196,8 @@ class NWRuntime(DesktopRuntime):
             # User specifies the executable, we're not going to worry about version
             exe = flexx.config.nw_exe
         else:
-            exe = self.get_runtime(min_version)
-            if sys.platform.startswith('win'):
-                exe = op.join(exe, 'nw.exe')
-            elif sys.platform.startswith('darwin'):
-                exe = op.join(exe, 'nwjs.app', 'Contents', 'MacOS', 'nwjs')
-            else:
-                exe = op.join(exe, 'nw')
+            # We install the runtime, based on a minimal required version
+            exe = self._get_exe_name(self.get_runtime(config.nw_min_version))
 `           
             # Change exe to avoid grouping + easier recognition in task manager
             if exe and op.isfile(op.realpath(exe)):

--- a/flexx/webruntime/tests/test_dont_leave_trails.py
+++ b/flexx/webruntime/tests/test_dont_leave_trails.py
@@ -1,0 +1,60 @@
+"""
+Verify that the app runtimes do not leave profile directories around. We've
+had xul spam the  user directory before, and we want to make sure that does not
+happen again.
+"""
+
+import os
+import time
+import tempfile
+
+from flexx import webruntime
+from flexx.util.testing import run_tests_if_main
+
+userdir = os.path.expanduser('~')
+
+
+def index():
+    """ Get a set of filenames for the current user directory.
+    """
+    filenames = set()
+    for root, dirs, files in os.walk(userdir):
+        for fname in files:
+            filenames.add(os.path.join(root, fname))
+    return filenames
+
+
+def notrailtester(runtime, n=4):
+    
+    html_filename = os.path.join(tempfile.gettempdir(), 'flexx_empty_page.html')
+    with open(html_filename, 'wb') as f:
+        f.write('<html><body>test page</body></html>'.encode())
+    
+    before = index()
+    
+    for i in range(n):
+        x = webruntime.launch(html_filename, 'xul')
+        time.sleep(1.5)
+        x.close()
+        time.sleep(0.5)
+    
+    after = index()
+    
+    extra_files = after.difference(before)
+    extra_files2 = [f for f in extra_files
+                    if not f.startswith((webruntime.TEMP_APP_DIR,
+                                         webruntime.RUNTIME_DIR))]
+    
+    print(extra_files2)
+    assert len(extra_files2) < n
+
+
+def test_notrail_xul():
+    notrailtester('xul')
+
+
+def test_notrail_xul():
+    notrailtester('nwjs')
+
+
+run_tests_if_main()

--- a/flexx/webruntime/xul.py
+++ b/flexx/webruntime/xul.py
@@ -277,6 +277,13 @@ class FirefoxRuntime(DesktopRuntime):
         app_path = create_temp_app_dir('xul')
         id = op.basename(app_path).split('_', 1)[1]
 
+        # Prepare profile dir for Xul to let -profile dir point to.
+        # This dir is unique for each instance of the app, but because it is
+        # inside the app_path, it gets automatically cleaned up.
+        profile_dir = op.join(app_path, 'stub_profile')
+        if not op.isdir(profile_dir):
+            os.mkdir(profile_dir)
+        
         # Set size and position
         size = self._kwargs.get('size', (640, 480))
         pos = self._kwargs.get('pos', None)
@@ -307,7 +314,8 @@ class FirefoxRuntime(DesktopRuntime):
             exe = self._get_app_exe(xul_exe, app_path)
         
         # Launch
-        cmd = [exe, '-app', op.join(app_path, 'application.ini')]
+        cmd = [exe, '-app', op.join(app_path, 'application.ini'),
+               '-profile', profile_dir]
         self._start_subprocess(cmd)
     
     def _launch_tab(self, url):


### PR DESCRIPTION
We already had this covered for NW.js, now we apply the same strategy for xul.