### PR TITLE
Show useful dialogs at runtime fail

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -16,7 +16,8 @@ config = Config('flexx', '~appdata/.flexx.cfg',
         ssl_keyfile=('', str, 'The key file for https server.'),
         
         # flexx.webruntime
-        webruntime=('', str, 'The default web runtime to use. Default is xul/browser.'),
+        webruntime=('', str, 'The default web runtime to use. '
+                    'Default is "app or browser".'),
         firefox_exe=('', str, 'The location of the Firefox executable. '
                      'Auto-detect by default.'),
         chrome_exe=('', str, 'The location of the Chrome/Chromium executable. '

--- a/flexx/app/_app.py
+++ b/flexx/app/_app.py
@@ -134,7 +134,8 @@ class App:
         """ Launch this app as a desktop app in the given runtime.
         
         Arguments:
-            runtime (str): the runtime to launch the application in. Default 'xul'.
+            runtime (str): the runtime to launch the application in.
+                Default 'app or browser'.
             runtime_kwargs: kwargs to pass to the ``webruntime.launch`` function.
                 A few names are passed to runtime kwargs if not already present
                 ('title' and 'icon').

--- a/flexx/app/_clientcore.py
+++ b/flexx/app/_clientcore.py
@@ -76,7 +76,7 @@ class Flexx:
             window.history.replaceState(window.history.state, '',
                                         window.location.pathname)
         except Exception:
-            pass  # e.g. Xul
+            pass  # e.g. firefox-app/nw
     
     def exit(self):
         """ Called when runtime is about to quit. """

--- a/flexx/app/_funcs.py
+++ b/flexx/app/_funcs.py
@@ -76,7 +76,8 @@ def init_interactive(cls=None, runtime=None):
         cls (None, Model): a subclass of ``app.Model`` (or ``ui.Widget``) to use
             as the *default active model*. Only has effect the first time that
             this function is called.
-        runtime (str): the runtime to launch the application in. Default 'xul'.
+        runtime (str): the runtime to launch the application in.
+            Default 'app or browser'.
     """
     
     # Determine default model class (which is a Widget if ui is imported)

--- a/flexx/app/tests/test_live.py
+++ b/flexx/app/tests/test_live.py
@@ -25,7 +25,7 @@ def runner(cls):
     # Run with a fresh server
     server = app.create_server(port=0, new_loop=True)
     
-    t = app.launch(cls, 'xul')
+    t = app.launch(cls, 'firefox-app')
     t.test_init()
     t.test_set_result()
     # Install failsafe. Use a closure so failsafe wont spoil a future test

--- a/flexx/ui/examples/leaflet.py
+++ b/flexx/ui/examples/leaflet.py
@@ -296,5 +296,5 @@ if __name__ == '__main__':
                     m.bindTooltip('%f, %f' % (latlng[0], latlng[1]))
                     m.addTo(self.leaflet.map)
 
-    app.launch(MapWidget, 'xul')
+    app.launch(MapWidget, 'app')
     app.run()

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -129,7 +129,7 @@ class LineEdit(Widget):
         def __placeholder_text_changed(self, *events):
             self.node.placeholder = self.placeholder_text
         
-        # todo: this works in Firefox but not in Xul
+        # todo: this works in the browser but not in e.g. firefox-app
         @event.connect('autocomp')
         def __autocomp_changed(self, *events):
             autocomp = self.autocomp

--- a/flexx/webruntime/__init__.py
+++ b/flexx/webruntime/__init__.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 del logging
 
 from .. import config
+from .. import dialite
 
 from ._manage import RUNTIME_DIR, TEMP_APP_DIR  # noqa
 from ._common import BaseRuntime, DesktopRuntime  # noqa
@@ -174,7 +175,6 @@ def launch(url, runtime=None, **kwargs):
         messages.extend(errors)
     messages = '\n\n'.join(messages)
     
-    from flexx import dialite  # noqa
     dialite.fail('Flexx - No suitable runtime available', messages)
     
     raise ValueError('Could not detect a suitable backend among %r.' % runtimes)

--- a/flexx/webruntime/__init__.py
+++ b/flexx/webruntime/__init__.py
@@ -14,6 +14,7 @@ Memory considerations
 
 """
 
+import sys
 import logging
 from collections import OrderedDict
 logger = logging.getLogger(__name__)
@@ -52,6 +53,8 @@ _aliases = {'app': 'firefox-app or nw-app',
             'chrome-app': 'googlechrome-app or chromium-app',
             }
 
+if sys.platform.startswith('win'):
+    _aliases['app'] = 'firefox-app or chrome-app or nw-app'
 
 # We require to specify -app or -browser suffixes, though old names still work
 _aliases_compat = {

--- a/flexx/webruntime/__init__.py
+++ b/flexx/webruntime/__init__.py
@@ -204,7 +204,8 @@ def launch(url, runtime=None, **kwargs):
             seen.add(rt.get_name())
             messages.append(c + ': ' + rt._get_install_instuctions())
     messages = '\n\n'.join(messages)
-    from flexx import dialite
+    
+    from flexx import dialite  # noqa
     dialite.fail('Flexx - No suitable runtime available', messages)
     
     raise ValueError('Could not detect a suitable backend among %r.' % runtimes)

--- a/flexx/webruntime/_browser.py
+++ b/flexx/webruntime/_browser.py
@@ -27,6 +27,9 @@ class BrowserRuntime(BaseRuntime):
         self._type = type or ''
         super().__init__(**kwargs)
     
+    def _get_install_instuctions(self):
+        return ''  # we know nothing of the browsers
+    
     def _get_name(self):
         return 'browser'
     

--- a/flexx/webruntime/_chrome.py
+++ b/flexx/webruntime/_chrome.py
@@ -34,6 +34,12 @@ class ChromeRuntime(DesktopRuntime):
     def _get_name(self):
         return 'chrome'
     
+    def _get_install_instuctions(self):
+        m = 'Install Chrome from http://chrome.com or https://www.chromium.org'
+        if sys.platform.startswith('linux'):
+            m += ', or use your package manager.'
+        return m
+    
     def _get_version(self, exe=None):
         if exe is None:
             exe = self.get_exe()
@@ -218,6 +224,9 @@ class GoogleChromeRuntime(ChromeRuntime):
     
     def _get_exe(self):
         return self._get_google_chrome_exe()
+    
+    def _get_install_instuctions(self):
+        return 'Install Google Chrome from http://chrome.com'
 
 
 class ChromiumRuntime(ChromeRuntime):
@@ -229,3 +238,9 @@ class ChromiumRuntime(ChromeRuntime):
     
     def _get_exe(self):
         return self._get_chromium_exe()
+    
+    def _get_install_instuctions(self):
+        m = 'Install Chromium from https://www.chromium.org'
+        if sys.platform.startswith('linux'):
+            m += ', or use your package manager.'
+        return m

--- a/flexx/webruntime/_chrome.py
+++ b/flexx/webruntime/_chrome.py
@@ -72,8 +72,8 @@ class ChromeRuntime(DesktopRuntime):
         exe = self.get_exe()
         version = self._get_version(exe)
         if not exe:
-            raise RuntimeError('You need to install Chrome / Chromium')
-            # todo: dialite
+            raise RuntimeError('Cannot use Chrome/Chromium runtime if corresponding '
+                               'browser is not installed on the system.')
         
         path = op.join(RUNTIME_DIR, self.get_name() + '_' + version)
         if sys.platform.startswith('win'):
@@ -98,10 +98,9 @@ class ChromeRuntime(DesktopRuntime):
         
         exe = self.get_exe()
         if exe is None:
-            raise RuntimeError('Chrome or Chromium browser was not detected.')
-            # todo: dialite
+            raise RuntimeError('Chrome/Chromium is not available on this system.')
         
-        # No way to set icon and title. On Wi,ndows, Chrome uses document
+        # No way to set icon and title. On Windows, Chrome uses document
         # title/icon. On OS X we create an app. On Linux ... tough luck
         # self._title ...
         # self._icon ...

--- a/flexx/webruntime/_common.py
+++ b/flexx/webruntime/_common.py
@@ -100,6 +100,12 @@ class BaseRuntime:
         t.setDaemon(True)
         t.start()  # tidy up
     
+    def get_install_instuctions(self):
+        """ Get instructions on how a runtime can be installed. Used internally
+        to show useful dialogs.
+        """
+        return self._get_install_instuctions()
+    
     def get_name(self):
         """ Get the name of the runtime.
         """
@@ -202,6 +208,13 @@ class BaseRuntime:
     
     ## Methods to implement in subclasses
     
+    def _get_install_instuctions(self):
+        """ Subclasses can let know how the user must install the runtime.
+        Can return None to indicate that it cannot be installed (like the
+        "default browser").
+        """
+        return "No info on how to install %s" % self.get_name()
+    
     def _get_name(self):
         """ Just make this return a string name.
         """
@@ -267,7 +280,7 @@ class DesktopRuntime(BaseRuntime):
     
     def get_runtime(self, min_version=None):
         """ Get the directory where (our local version of) the runtime is
-        located. If necessary, the runtime is installed or updated.
+        located. If necessary, the runtime is chached / installed in some way.
         """
         cur_version = self.get_current_version() or ''
         path = op.join(RUNTIME_DIR, self.get_name() + '_' + cur_version)
@@ -306,7 +319,6 @@ class DesktopRuntime(BaseRuntime):
             raise
         
         return op.join(RUNTIME_DIR, self.get_name() + '_' + self.get_current_version())
-        
     
     def get_current_version(self):
         """ Get the (highest) version of this runtime that we currently have.

--- a/flexx/webruntime/_common.py
+++ b/flexx/webruntime/_common.py
@@ -104,7 +104,7 @@ class BaseRuntime:
         """ Get instructions on how a runtime can be installed. Used internally
         to show useful dialogs.
         """
-        return self._get_install_instuctions()
+        return self._get_install_instuctions().strip()
     
     def get_name(self):
         """ Get the name of the runtime.
@@ -295,19 +295,11 @@ class DesktopRuntime(BaseRuntime):
         elif versionstring(cur_version) < versionstring(min_version):
             install_action = 'update'
         
-        # Install if necessary
+        # Install if necessary and update version
         if install_action:
             logger.info('Performing %s of runtime %s' %
                         (install_action, self.get_name()))
-            try:
-                self._install_runtime()
-            except Exception as err:
-                from flexx import dialite  # noqa
-                dialite.fail('Flexx - Error with runtime %s' % self.get_name(),
-                             'Could not locally install runtime %s:\n\n%s' %
-                             (self.get_name(), str(err)))
-                raise err
-            # Update cur_version
+            self._install_runtime()
             cur_version = self.get_current_version()
             assert cur_version
         

--- a/flexx/webruntime/_firefox.py
+++ b/flexx/webruntime/_firefox.py
@@ -128,7 +128,13 @@ class FirefoxRuntime(DesktopRuntime):
     
     def _get_name(self):
         return 'firefox'
-        
+    
+    def _get_install_instuctions(self):
+        m = 'Install Mozilla Firefox from http://firefox.com'
+        if sys.platform.startswith('linux'):
+            m += ', or use your package manager.'
+        return m
+    
     def _get_exe(self):
         
         # Return user-specified version?

--- a/flexx/webruntime/_firefox.py
+++ b/flexx/webruntime/_firefox.py
@@ -26,9 +26,6 @@ from ._common import DesktopRuntime
 from ._manage import create_temp_app_dir, RUNTIME_DIR
 
 
-# todo: enable fullscreen - does not seem to work on XUL
-
-
 ## File templates
 
 # The Profile setting makes all apps use the same dummy profile (see issue #150)
@@ -229,8 +226,8 @@ class FirefoxRuntime(DesktopRuntime):
         exe = self.get_exe()
         version = self._get_version(exe)
         if not exe:
-            raise RuntimeError('You need to install Firefox')
-            # todo: dialite
+            raise RuntimeError('Cannot use Firefox runtime if Firefox is not '
+                               'installed on the system.')
         
         path = op.join(RUNTIME_DIR, self.get_name() + '_' + version)
         if sys.platform.startswith('win'):
@@ -263,7 +260,7 @@ class FirefoxRuntime(DesktopRuntime):
         # Get executable for xul runtime (may be None)
         ff_exe = self.get_exe()
         if not ff_exe:
-            raise RuntimeError('Firefox needs to be installed')  # todo: dialite
+            raise RuntimeError('Firefox is not available on this system.')
         elif not op.isfile(ff_exe):
             # We have no way to wrap things up in a custom app
             exe = ff_exe

--- a/flexx/webruntime/_manage.py
+++ b/flexx/webruntime/_manage.py
@@ -11,7 +11,10 @@ import os.path as op
 import os
 import sys
 import time
+import stat
 import shutil
+import tarfile
+import zipfile
 import subprocess
 
 from . import logger
@@ -290,14 +293,10 @@ def create_temp_app_dir(prefix, cleanup=60):
 def open_arch(filename):
     """ Open archive, returning the zipfile or tarfile object.
     """
-    
-    import tarfile
-    import zipfile
     if filename.endswith(('.tar', '.tar.gz', '.tar.bz2')):
         arch_func = tarfile.open
     elif filename.endswith('.zip'):
         arch_func = zipfile.ZipFile
-    
     return arch_func(filename, mode='r')
 
 
@@ -331,7 +330,6 @@ def extract_arch(archive, dir_name):
     print('done')
     
     # Enable executables for OS X
-    import stat
     for dirpath, dirnames, filenames in os.walk(temp_dir_name):
         if dirpath.endswith('/Contents/MacOS'):
             for fname in filenames:

--- a/flexx/webruntime/_manage.py
+++ b/flexx/webruntime/_manage.py
@@ -13,7 +13,6 @@ import sys
 import time
 import shutil
 import subprocess
-from urllib.request import urlopen, Request
 
 from . import logger
 
@@ -288,162 +287,21 @@ def create_temp_app_dir(prefix, cleanup=60):
     return path
 
 
-def download_runtime(runtime_name, version, url):
+def open_arch(filename):
+    """ Open archive, returning the zipfile or tarfile object.
     """
-    Function for downloading a runtime.
     
-    * Download archive as xxx.zip~pid
-    * On download complete, rename to xxx.zip
-    * Extract to yyy~pid
-    * When extract is done, rename to yyy
-    
-    For downloading, we compare the pid to current list of pids to see
-    if perhaps another process is already downloading it (though its no
-    guarantee, as pids are reused). If there is an archive in progress,
-    which has "stalled", we rename the archive and continue downloading.
-    """
-
-    # Calculate file system locations
-    fname = url.split('?')[0].split('~')[0].split('/')[-1].lower()
-    archive_name = op.join(RUNTIME_DIR, fname)
-    dir_name = op.join(RUNTIME_DIR, runtime_name + '_' + version)
-    
-    # Get func to open archive
     import tarfile
     import zipfile
-    if fname.endswith(('.tar', '.tar.gz', '.tar.bz2')):
+    if filename.endswith(('.tar', '.tar.gz', '.tar.bz2')):
         arch_func = tarfile.open
-    elif fname.endswith('.zip'):
+    elif filename.endswith('.zip'):
         arch_func = zipfile.ZipFile
-    else:
-        raise ValueError('Dont know how to extract from %s' % fname)
     
-    # Go!
-    if op.isdir(dir_name):
-        return
-    if _download(url, archive_name):
-        _extract(archive_name, dir_name, arch_func)
-    
-    # Remove archive
-    remove(archive_name)
-    
-    # Note, if for some reason the runtime is corrupt, the user can goto
-    # flexx.webruntime.RUNTIME_DIR and delete it. This solution works for
-    # devs but less so for end-users. So frozen apps should either ship the
-    # runtime along, or use the firefox-app runtime.
+    return arch_func(filename, mode='r')
 
 
-def _download(url, archive_name):
-    """ Download the archive.
-    """
-    temp_archive_name = '%s~%i' % (archive_name, os.getpid())
-    
-    # Clean, just to be sure
-    remove(temp_archive_name)
-    
-    # Maybe the archive is already there ...
-    if op.isfile(archive_name):
-        return True
-    
-    # Get whether the downloading is already in progress by another process
-    pids = get_pid_list()
-    # pids.remove(os.getpid())
-    archives = []  # that do not correspond to an existing pid other than us
-    for name in os.listdir(RUNTIME_DIR):
-        filename = op.join(RUNTIME_DIR, name)
-        if filename.startswith(archive_name):
-            try:
-                pid = int(name.split('~')[-1])
-            except ValueError:
-                continue  # what is this? not ours, probably
-            if pid and pid in pids:
-                # another process might be working on it
-                if False:  # noqa - maybe we want a silent update at some point?
-                    return
-            else:
-                archives.append(filename)
-    
-    # Touch file to clear it and tell other processes that we're loading it,
-    # or proceed with existing (partial) file.
-    if not archives:
-        with open(temp_archive_name, 'wb'):
-            pass
-    else:
-        try:
-            os.rename(archives[0], temp_archive_name)
-        except FileNotFoundError:
-            raise  # another process was just a wee bit earlier?
-    
-    # Open folder in native file explorer for user to see progress
-    _open_folder(op.dirname(archive_name))
-    
-    # Create a file that we keep renaming to indicate progress
-    progress_name_t = '%s~ progress %%0.0f %%%% ~%i' % (archive_name, os.getpid())
-    progress_name = progress_name_t % 0
-    with open(progress_name, 'wb'):
-        pass
-    
-    # Open local file ...
-    t0 = time.time()
-    with open(temp_archive_name, 'ab') as f_dst:
-        tries = 0
-        
-        while tries < 5:
-            tries += 1
-            
-            try:
-                nbytes = f_dst.tell()
-                # Open remote resource
-                r = Request(url)
-                r.headers['Range'] = 'bytes=%i-' % nbytes
-                f_src = urlopen(r, timeout=5)
-                file_size = nbytes + int(f_src.headers['Content-Length'].strip())
-                chunksize = 64 * 1024
-                # Download in chunks
-                while True:
-                    chunk = f_src.read(chunksize)
-                    if not chunk:
-                        break
-                    nbytes += len(chunk)
-                    f_dst.write(chunk)
-                    f_dst.flush()
-                    # Show percentage done in console
-                    percentage = 100 * nbytes / file_size
-                    print('downloading: %03.1f%%\r' % percentage, end='')
-                    # Show percentahe done in FS
-                    progress_name2 = progress_name_t % percentage
-                    if progress_name2 != progress_name:
-                        try:
-                            os.rename(progress_name, progress_name2)
-                            progress_name = progress_name2
-                        except Exception:
-                            pass
-            
-            except (OSError, IOError) as err:
-                if tries < 4:
-                    logger.warn('%s. Retrying ...' % str(err))
-                    time.sleep(0.2)
-                    continue
-                raise
-            break  # retry loop
-    
-    print('Downloaded %s in %1.f s' % (url, time.time() - t0))
-    
-    if op.isfile(progress_name):
-        try:
-            os.remove(progress_name)
-        except Exception:
-            pass
-    
-    # Mark archive as done
-    if op.isfile(archive_name):
-        pass  # another process beat us to it
-    else:
-        os.rename(temp_archive_name, archive_name)
-    return True
-    
-    
-def _extract(archive_name, dir_name, arch_func):
+def extract_arch(archive, dir_name):
     """ Extract an archive that contains a runtime.
     """
     temp_dir_name = dir_name + '~' + str(os.getpid())
@@ -453,13 +311,8 @@ def _extract(archive_name, dir_name, arch_func):
         return
     
     # Extract it
-    try:
-        print('Extracting ...', end='')
-        with arch_func(archive_name, mode='r') as archive:
-            archive.extractall(temp_dir_name)
-    except Exception:
-        remove(archive_name)  # it might be corrupt
-        raise
+    print('Extracting ...', end='')
+    archive.extractall(temp_dir_name)
     
     # Pop out empty dirs
     while True:
@@ -469,10 +322,10 @@ def _extract(archive_name, dir_name, arch_func):
         else:
             pop_dir = subdirs[0] + '~temp'
             os.rename(op.join(temp_dir_name, subdirs[0]),
-                      op.join(temp_dir_name, pop_dir))
+                    op.join(temp_dir_name, pop_dir))
             for name in os.listdir(op.join(temp_dir_name, pop_dir)):
                 os.rename(op.join(temp_dir_name, pop_dir, name),
-                          op.join(temp_dir_name, name))
+                        op.join(temp_dir_name, name))
             os.rmdir(op.join(temp_dir_name, pop_dir))
     
     print('done')
@@ -492,14 +345,3 @@ def _extract(archive_name, dir_name, arch_func):
     else:
         os.rename(temp_dir_name, dir_name)
     return True
-
-
-def _open_folder(path):
-    """ Open folder in native file explorer, on Windows, OS X and Linux.
-    """
-    if sys.platform.startswith('win'):
-        os.startfile(path)
-    elif sys.platform.startswith('darwin'):
-        subprocess.Popen(["open", path])
-    else:
-        subprocess.Popen(["xdg-open", path])

--- a/flexx/webruntime/_ms.py
+++ b/flexx/webruntime/_ms.py
@@ -8,6 +8,8 @@ import sys
 from ._common import BaseRuntime
 
 
+# todo: ensure good behavior on other OSes, e.g. should _get_exe() raise?
+
 class MicrosoftRuntime(BaseRuntime):
     """ Base class for IE and Edge runtimes.
     """

--- a/flexx/webruntime/_ms.py
+++ b/flexx/webruntime/_ms.py
@@ -11,6 +11,11 @@ from ._common import BaseRuntime
 class MicrosoftRuntime(BaseRuntime):
     """ Base class for IE and Edge runtimes.
     """
+    
+    def _get_install_instuctions(self):
+        # IE / Edge is installed, or not, but usually there is little choice
+        return ''
+    
     def _get_version(self):
         return None
 

--- a/flexx/webruntime/_nw.py
+++ b/flexx/webruntime/_nw.py
@@ -25,6 +25,7 @@ import re
 import sys
 import json
 import struct
+import tempfile
 from urllib.request import urlopen
 
 from .. import config
@@ -107,6 +108,17 @@ class NWRuntime(DesktopRuntime):
     
     def _get_name(self):
         return 'nw'
+    
+    def _get_install_instuctions(self):
+        # Get possible dirs
+        dirs = op.normpath(op.expanduser('~/Downloads')), tempfile.gettempdir()
+        dirs = ['"%s"' % d for d in dirs if op.isdir(d)]
+        dirs = ' or '.join(dirs)
+        
+        m = ('Download the NW.js archive for your platform from '
+             '"http://mwjs.io". Flexx will find the file if it is placed in %s '
+             '(the default location for most browsers).' % dirs)
+        return m
     
     def _get_exe_name(self, dir):
         if sys.platform.startswith('win'):

--- a/flexx/webruntime/_nw.py
+++ b/flexx/webruntime/_nw.py
@@ -274,12 +274,13 @@ class NWRuntime(DesktopRuntime):
     def _clean_nw_dirs(self):
         """ NW makes empty dirs in temp dir, clean these up.
         """
-        dir = tempfile.gettempdir()
-        for dname in os.listdir(dir):
-            if dname.startswith('nw'):
-                dirname = os.path.join(dir, dname)
-                if not os.listdir(dirname):
-                    try:
-                        os.rmdir(dirname)
-                    except Exception:
-                        pass
+        if sys.patform.startswih('win'):  # only an issue on Windows
+            dir = tempfile.gettempdir()
+            for dname in os.listdir(dir):
+                if dname.startswith('nw'):
+                    dirname = os.path.join(dir, dname)
+                    if not os.listdir(dirname):
+                        try:
+                            os.rmdir(dirname)
+                        except Exception:
+                            pass

--- a/flexx/webruntime/_nw.py
+++ b/flexx/webruntime/_nw.py
@@ -109,7 +109,7 @@ class NWRuntime(DesktopRuntime):
     
     def _get_install_instuctions(self):
         m = ('Download the NW.js archive for your platform from '
-             '"http://mwjs.io". Flexx will find the file if it is placed in '
+             '"http://nwjs.io". Flexx will find the file if it is placed in '
              'your home dir, desktop, downloads dir (where most browser save '
              'it) or the default temp dir.')
         return m
@@ -274,7 +274,7 @@ class NWRuntime(DesktopRuntime):
     def _clean_nw_dirs(self):
         """ NW makes empty dirs in temp dir, clean these up.
         """
-        if sys.patform.startswih('win'):  # only an issue on Windows
+        if sys.platform.startswith('win'):  # only an issue on Windows
             dir = tempfile.gettempdir()
             for dname in os.listdir(dir):
                 if dname.startswith('nw'):

--- a/flexx/webruntime/_nw.py
+++ b/flexx/webruntime/_nw.py
@@ -206,6 +206,7 @@ class NWRuntime(DesktopRuntime):
     def _launch_app(self, url):
         
         self._test_platform()
+        self._clean_nw_dirs()
         
         # Get dir to store app definition
         app_path = create_temp_app_dir('nw')
@@ -269,3 +270,16 @@ class NWRuntime(DesktopRuntime):
         # Launch
         cmd = [exe, '--user-data-dir=' + profile_dir, app_path]
         self._start_subprocess(cmd, LD_LIBRARY_PATH=llp)
+    
+    def _clean_nw_dirs(self):
+        """ NW makes empty dirs in temp dir, clean these up.
+        """
+        dir = tempfile.gettempdir()
+        for dname in os.listdir(dir):
+            if dname.startswith('nw'):
+                dirname = os.path.join(dir, dname)
+                if not os.listdir(dirname):
+                    try:
+                        os.rmdir(dirname)
+                    except Exception:
+                        pass

--- a/flexx/webruntime/_qt.py
+++ b/flexx/webruntime/_qt.py
@@ -83,6 +83,10 @@ class PyQtRuntime(DesktopRuntime):
     def _get_name(self):
         return 'pyqt'
     
+    def _get_install_instuctions(self):
+        return ('To enable the Pyqt runtime, install Pyqt5, Pyqt4, '
+                'Pyside2 or Pyside in your Python environment.')
+    
     def _get_exe(self):
         return sys.executable
         # todo: perhaps we should test whether pyqt is available, but

--- a/flexx/webruntime/_selenium.py
+++ b/flexx/webruntime/_selenium.py
@@ -18,6 +18,10 @@ class SeleniumRuntime(BaseRuntime):
         self._type = type or ''
         super().__init__(**kwargs)
     
+    def _get_install_instuctions(self):
+        return ('To enable the Selenium runtime, install selenium '
+                'in your Python environment.')
+    
     def _get_name(self):
         return 'selenium'
     

--- a/flexx/webruntime/tests/test_dont_leave_trails.py
+++ b/flexx/webruntime/tests/test_dont_leave_trails.py
@@ -19,6 +19,10 @@ def index():
     """
     filenames = set()
     for root, dirs, files in os.walk(userdir):
+        for fname in dirs:
+            if 'temp' not in fname.lower():
+                # hacky exception for firefox, which seems to clean things up itself
+                filenames.add(os.path.join(root, fname))
         for fname in files:
             filenames.add(os.path.join(root, fname))
     return filenames


### PR DESCRIPTION
This PR adds lets the `webruntime .launch()` function make use of the dialite package to show a dialog when the runtime is not available or fails, or when none of the possible runtimes is available. This provides a friendly way to present the user with instructions for installing a runtime, which is particularly important for frozen applications (when the end-user can be non-programmers).