### PR TITLE
Support Python 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,9 @@ branches:
 
 matrix:
     include:
-        - python: "3.5"
+        - python: "3.6"
           env: TEST_UNIT=0 TEST_STYLE=1
-        - python: "3.5"
+        - python: "3.6"
           env: TEST_UNIT=0 TEST_DOCS=1
         #
         - python: "2.7"
@@ -28,8 +28,10 @@ matrix:
         - python: "3.3"
           env: TEST_UNIT=1
         - python: "3.4"
-          env: TEST_UNIT=1 TEST_INSTALL=1
+          env: TEST_UNIT=1
         - python: "3.5"
+          env: TEST_UNIT=1 TEST_INSTALL=1
+        - python: "3.6"
           env: TEST_UNIT=1
 
 before_install:

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2016, Flexx developers
+Copyright (c) 2015-2017, Flexx developers
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -74,7 +74,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Flexx'
-copyright = '2016, Flexx contributors'
+copyright = '2015-2017, Flexx contributors'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/scripts/genexamples.py
+++ b/docs/scripts/genexamples.py
@@ -26,7 +26,9 @@ created_files = []
 
 def get_notebook_list():
     url = 'http://api.github.com/repos/zoofio/flexx-notebooks/contents'
+    print('downloading %s ... ' % url, end='')
     s = json.loads(urlopen(url, timeout=5.0).read().decode())
+    print('done')
     filenames = []
     for file in s:
         if file['name'].endswith('ipynb'):
@@ -94,7 +96,7 @@ def main():
             # Include notebooks?
             for fname in notebook_list:
                 if fname.endswith('.ipynb') and ('_%s.' % sub) in fname:
-                    url = 'http://github.com/zoofIO/flexx-notebooks/blob/master/' + fname
+                    url = 'https://github.com/zoofIO/flexx-notebooks/blob/master/' + fname
                     docs += '* `%s <%s>`_ (external notebook)\n' % (fname, url)
             # List examples
             for name in sorted(examples[sub]):

--- a/flexx/app/_model.py
+++ b/flexx/app/_model.py
@@ -184,7 +184,9 @@ class ModelMeta(HasEventsMeta):
             Both = new_type('Both', (), {})
             setattr(cls, 'Both', Both)
         
-        # Copy properties from Both class to main class and JS class
+        # Copy properties from Both class to main class and JS class. Note that
+        # in Python 3.6 we iterate in the order in which the items are defined,
+        # though we currently do not preserve the order of Both/JS.
         for name, val in cls.Both.__dict__.items():
             if name.startswith('__') and name.endswith('__'):
                 continue

--- a/flexx/event/_js.py
+++ b/flexx/event/_js.py
@@ -2,6 +2,7 @@
 Implementation of flexx.event in JS via PyScript.
 """
 
+import sys
 import json
 
 from flexx.pyscript import JSString, py2js as py2js_
@@ -258,7 +259,12 @@ def create_js_hasevents_class(cls, cls_name, base_class='HasEvents.prototype'):
     OK_MAGICS = ('__properties__', '__emitters__', '__handlers__',
                  '__local_properties__')
     
-    for name, val in sorted(cls.__dict__.items()):
+    # Process class items in original order or sorted by name if we cant
+    class_items = cls.__dict__.items()
+    if sys.version_info < (3, 6):
+        class_items = sorted(class_items)
+    
+    for name, val in class_items:
         name = name.replace('_JS__', '_%s__' % cls_name.split('.')[-1])  # fix mangling
         if isinstance(val, BaseEmitter):
             funcname = name

--- a/flexx/ui/examples/send_data.py
+++ b/flexx/ui/examples/send_data.py
@@ -36,7 +36,7 @@ else:
     import ctypes
     data = (ctypes.c_double * N)()
     for i in range(N):
-        data[i] = random.random(0, 1)
+        data[i] = random.random()
 
 
 class SendData(ui.Widget):
@@ -49,7 +49,8 @@ class SendData(ui.Widget):
         
         # Send data to the JS side. In this case we don't need meta data
         meta = {}
-        self.send_data(bytes(data), meta)
+        bb = data.tobytes() if hasattr(data, 'tobytes') else bytes(data)
+        self.send_data(bb, meta)
     
     class JS:
         

--- a/flexx/util/icon.py
+++ b/flexx/util/icon.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (c) 2016, Almar Klein
+# Copyright (c) 2015-2017, Almar Klein
 # This module is distributed under the terms of the new BSD License.
 
 """

--- a/setup.py
+++ b/setup.py
@@ -151,5 +151,6 @@ setup(
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
     ],
 )


### PR DESCRIPTION
* [x] Test with Python 3.6 on Travis
* [x] If necessary, update any references to Python 3.5
* [x] Update copyright dates while we're at it
* [x] Update commonast for f-strings
* [ ] Maybe add initial support for f-string formatting (see #311)
* [x] The order of methods can be preserved in Python 3.6

Notes:
* Python 3.6 introduced `ast.Constant` but `ast.parse()` does not seem to produce it; its intended for 3d party libs.
* Python 3.6 allows underscores as string literals, the produced ast produced regular literals, so no action required.