### PR TITLE
Cookies!

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -14,6 +14,7 @@ config = Config('flexx', '~appdata/.flexx.cfg',
                  'it is closed.'),
         ssl_certfile=('', str, 'The cert file for https server.'),
         ssl_keyfile=('', str, 'The key file for https server.'),
+        cookie_secret=('flexx_secret', str, 'The secret key to encode cookies.'),
         
         # flexx.webruntime
         webruntime=('', str, 'The default web runtime to use. '

--- a/flexx/app/_app.py
+++ b/flexx/app/_app.py
@@ -337,7 +337,7 @@ class AppManager(event.HasEvents):
         except Exception as err:
             logger.error('Error when clearing old pending sessions: %s' % str(err))
     
-    def create_session(self, name, id=None):
+    def create_session(self, name, id=None, cookies=None):
         """ Create a session for the app with the given name.
         
         Instantiate an app and matching session object corresponding
@@ -360,6 +360,7 @@ class AppManager(event.HasEvents):
         
         # Create the session
         session = Session(name)
+        session._set_cookies(cookies)
         if id is not None:
             session._id = id  # used by app.export
         self._session_map[session.id] = session
@@ -377,7 +378,7 @@ class AppManager(event.HasEvents):
         logger.debug('Instantiate app client %s' % session.app_name)
         return session
     
-    def connect_client(self, ws, name, session_id):
+    def connect_client(self, ws, name, session_id, cookies=None):
         """ Connect a client to a session that was previously created.
         """
         _, pending, connected = self._appinfo[name]
@@ -394,6 +395,7 @@ class AppManager(event.HasEvents):
         # Add app to connected, set ws
         assert session.status == Session.STATUS.PENDING
         logger.info('New session %s %s' %(name, session_id))
+        session._set_cookies(cookies)
         session._set_ws(ws)
         connected.append(session)
         AppManager.total_sessions += 1

--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -243,6 +243,10 @@ class Session:
         value in your server. Additional keyword arguments are set on
         the Cookie.Morsel directly.
         """
+        # This code is taken (in modified form) from the Tornado project
+        # Copyright 2009 Facebook
+        # Licensed under the Apache License, Version 2.0 
+        
         # Assume tornado is available ...
         from tornado.escape import native_str
         from tornado.httputil import format_timestamp

--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -224,6 +224,7 @@ class Session:
     
     def get_cookie(self, name, default=None, max_age_days=31, min_version=None):
         """ Gets the value of the cookie with the given name, else default.
+        Note that cookies only really work for web apps.
         """
         from tornado.web import decode_signed_value
         if name in self._cookies:

--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -5,11 +5,11 @@ Definition of the Session class.
 import re
 import time
 import json
-import http
 import random
 import hashlib
 import weakref
 import datetime
+from http.cookies import SimpleCookie
 
 from ._model import Model, new_type
 from ._asset import Asset, Bundle, solve_dependencies
@@ -208,7 +208,7 @@ class Session:
         main model is instantiated. Otherwise they are set when the websocket
         is connected.
         """
-        self._cookies = cookies if cookies else http.cookies.SimpleCookie()
+        self._cookies = cookies if cookies else SimpleCookie()
     
     def _set_app(self, model):
         if self._model is not None:

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -307,7 +307,7 @@ class AppHandler(FlexxHandler):
                 self.redirect('/%s/' % app_name)  # redirect for normal serve
         else:
             # Create session - websocket will connect to it via session_id
-            session = manager.create_session(app_name)
+            session = manager.create_session(app_name, cookies=self.cookies)
             self.write(get_page(session).encode())
 
 
@@ -556,7 +556,8 @@ class WSHandler(WebSocketHandler):
                 session_id = message.split(' ', 1)[1].strip()
                 try:
                     self._session = manager.connect_client(self, self.app_name,
-                                                           session_id)
+                                                           session_id,
+                                                           cookies=self.cookies)
                 except Exception as err:
                     self.close(1003, "Could not launch app: %r" % err)
                     raise

--- a/flexx/ui/examples/cookies.py
+++ b/flexx/ui/examples/cookies.py
@@ -1,0 +1,23 @@
+"""
+Tiny example for using cookies to store user data accross sessions.
+"""
+
+from flexx import app, ui, event
+
+
+class Cookies(ui.Widget):
+    
+    def init(self):
+        
+        ui.Label(text='Refreshing the page should maintain the value of the line edit.')
+        self.edit = ui.LineEdit(placeholder_text='username',
+                                text=self.session.get_cookie('username', ''))
+        
+    @event.connect('edit.text')
+    def _update_cookie(self, *events):
+        self.session.set_cookie('username', self.edit.text)
+
+
+if __name__ == '__main__':
+    m = app.launch(Cookies, 'browser')
+    app.serve()


### PR DESCRIPTION
This PR adds functionality to the `Session` class to set and get (encrypted) cookies. Also adds an example to demonstrate the use of cookies.

Note that cookies don't really work for desktop apps, and when launching an app with `app.launch()`, the cookies only become available when the websocket is set, which is *after* the main model initializes. For served web apps (which I expect to be the only real use-case for this feature) this is not a problem.