### PR TITLE
Corrected typo in flexx.pyscript documentation

### DIFF
--- a/flexx/pyscript/__init__.py
+++ b/flexx/pyscript/__init__.py
@@ -12,7 +12,7 @@ PyScript is a tool to write JavaScript using (a subset) of the Python
 language. All relevant buildins, and the methods of list, dict and str
 are supported. Not supported are set, slicing with steps,
 ``**kwargs``, ``with``, ``yield``. Imports are not supported. Other than that,
-most Python code should work as expected, though if you pry hard enough the
+most Python code should work as expected, though if you try hard enough the
 JavaScript may shine through. As a rule of thumb, the code should behave
 as expected when correct, but error reporting may not be very Pythonic.
 


### PR DESCRIPTION
Changed `pry` to `try` in `flexx/pyscript/__init__.py` file.
This typo showed itself in the [auto-generated documentation](http://flexx.readthedocs.io/en/latest/pyscript/intro.html#quick-intro)