### PR TITLE
Fix embedding SplitPanel (and others) in VBox with Widget in between

### DIFF
--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -792,5 +792,9 @@ class Widget(Model):
                             self.outernode.classList.add('flx-hbox')
                         else:
                             self.outernode.classList.add('flx-vbox')
-                    elif 'flx-BoxPanel' in subClassName:
+                    elif ('flx-BoxPanel' in subClassName or 
+                          'flx-SplitPanel' in subClassName or
+                          'flx-DockPanel' in subClassName or
+                          'flx-StackPanel' in subClassName or
+                          'flx-TabPanel' in subClassName):
                         self.outernode.classList.add('flx-abs-children')


### PR DESCRIPTION
Was fixed for BoxPanel, but not for several other layout classes that use absolute positioning.