### PR TITLE
Less memory leaks

### DIFF
--- a/flexx/app/_clientcore.py
+++ b/flexx/app/_clientcore.py
@@ -92,6 +92,13 @@ class Flexx:
         else:
             return self.instances[id]
     
+    def dispose_object(self, id):
+        """ Dispose the object with the given id.
+        """
+        ob = self.instances[id]
+        if ob is not undefined:
+            ob.dispose()  # Model.dispose() removes itself from flexx.instances
+    
     def spin(self, text='*'):
         RawJS("""
         if (!window.document.body) {return;}

--- a/flexx/event/_handler.py
+++ b/flexx/event/_handler.py
@@ -352,6 +352,7 @@ class Handler:
             while len(connection.objects):
                 ob, type = connection.objects.pop(0)
                 ob.disconnect(type, self)
+        self._connections = []
         while len(self._pending):
             self._pending.pop()  # no list.clear on legacy py
 

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -141,15 +141,18 @@ class Widget(Model):
         """ Overloaded version of dispose() that will also
         dispose any child widgets.
         """
+        # Dispose children? Yes, each widget can have exactly one parent and
+        # when that parent is disposed, it makes sense to assume that the
+        # child ought to be disposed as well. It avoids memory leaks. If a
+        # child is not supposed to be disposed, the developer should orphan the
+        # child widget.
         children = self.children
-        self.children = []
-        # Dispose children? Yes, it makes sense because each widget can
-        # have exactly one parent and when that parent is disposed, it
-        # makes sense to assume that the child ought to be disposed as
-        # well. It avoids memory leaks. If a child is not supposed to
-        # be disposed, the developer should orphan the child widget.
+        # First dispose children (so they wont send messages back), then clear
+        # the children and dispose ourselves.
         for child in children:
             child.dispose()
+        self.parent = None
+        self.children = ()  # tuple, to avoid triggering a reset when called twice
         super().dispose()
     
     @event.connect('parent:aaa')
@@ -373,7 +376,7 @@ class Widget(Model):
                 except Exception as err:
                     print(err)
             super().dispose()
-            
+        
         @event.connect('style')
         def __style_changed(self, *events):
             """ Emits when the style signal changes, and provides a dict with

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -138,8 +138,7 @@ class Widget(Model):
         pass
 
     def dispose(self):
-        """ Overloaded version of dispose() that will also
-        dispose any child widgets.
+        """ Overloaded version of dispose() that disposes any child widgets.
         """
         # Dispose children? Yes, each widget can have exactly one parent and
         # when that parent is disposed, it makes sense to assume that the
@@ -151,9 +150,9 @@ class Widget(Model):
         # the children and dispose ourselves.
         for child in children:
             child.dispose()
-        self.parent = None
-        self.children = ()  # tuple, to avoid triggering a reset when called twice
         super().dispose()
+        self.parent = None
+        self._children_value = ()  # tuple, to avoid triggering a reset when called twice
     
     @event.connect('parent:aaa')
     def __keep_alive(self, *events):
@@ -366,7 +365,8 @@ class Widget(Model):
             return _phosphor_widget.Widget({'node': node})
         
         def dispose(self):
-            """ Overloaded version of dispose() that will also dispose phosphor widget.
+            """ Overloaded version of dispose() that disposes phosphor widget
+            as well as any child widgets.
             """
             if self.phosphor:
                 try:
@@ -376,6 +376,8 @@ class Widget(Model):
                 except Exception as err:
                     print(err)
             super().dispose()
+            self.parent = None
+            self._children_value = ()
         
         @event.connect('style')
         def __style_changed(self, *events):

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -142,10 +142,14 @@ class Widget(Model):
         dispose any child widgets.
         """
         children = self.children
+        self.children = []
+        # Dispose children? Yes, it makes sense because each widget can
+        # have exactly one parent and when that parent is disposed, it
+        # makes sense to assume that the child ought to be disposed as
+        # well. It avoids memory leaks. If a child is not supposed to
+        # be disposed, the developer should orphan the child widget.
         for child in children:
             child.dispose()
-        if self.session.status:
-            self._session._exec('flexx.instances.%s.phosphor.dispose();' % self._id)
         super().dispose()
     
     @event.connect('parent:aaa')
@@ -308,26 +312,10 @@ class Widget(Model):
             # children are changed from the outside, but this is non-trivial
             # and easily leads to strange recursions. E.g. we temporarily remove
             # widgets ourselves to get the order straight.
-            that = self
-            def msg_hook(handler, msg):
-                if msg.type == 'resize':
-                    that._check_real_size()
-                elif msg.type == 'close-request':
-                    pass  # not sure what close means in Phosphor
-                elif msg.type == 'child-added':
-                    if msg.child.id not in window.flexx.instances:
-                        if not msg.child.node.classList.contains('p-TabBar'):
-                            print('Phosphor child %r added to %r that is not '
-                                'managed by Flexx.' % (msg.child.id, self.id))
-                    elif window.flexx.instances[msg.child.id] not in self.children:
-                        print('Phosphor child %s added without Flexx knowing' %
-                              msg.child.id)
-                elif msg.type == 'child-removed':
-                    pass
-                return True  # resume processing the message as normal
-            _phosphor_messaging.installMessageHook(self.phosphor, msg_hook)
+            _phosphor_messaging.installMessageHook(self.phosphor,
+                                                   self._phosphor_msg_hook)
             
-            # Keep track of Phosphor changing the title
+            # Keep track of Phosphor. Phosphor clears this ref when it is disposed.
             def _title_changed_in_phosphor(title):
                 self.title = title.label
             self.phosphor.title.changed.connect(_title_changed_in_phosphor)
@@ -345,6 +333,23 @@ class Widget(Model):
             else:
                 raise RuntimeError('Error determining class names for %s' % self.id)
         
+        def _phosphor_msg_hook(self, handler, msg):
+            if msg.type == 'resize':
+                self._check_real_size()
+            elif msg.type == 'close-request':
+                pass  # not sure what close means in Phosphor
+            elif msg.type == 'child-added':
+                if msg.child.id not in window.flexx.instances:
+                    if not msg.child.node.classList.contains('p-TabBar'):
+                        print('Phosphor child %r added to %r that is not '
+                            'managed by Flexx.' % (msg.child.id, self.id))
+                elif window.flexx.instances[msg.child.id] not in self.children:
+                    print('Phosphor child %s added without Flexx knowing' %
+                            msg.child.id)
+            elif msg.type == 'child-removed':
+                pass
+            return True  # resume processing the message as normal
+    
         def _init_phosphor_and_node(self):
             """ Overload this in sub widgets.
             """
@@ -357,6 +362,18 @@ class Widget(Model):
             node = window.document.createElement(element_name)
             return _phosphor_widget.Widget({'node': node})
         
+        def dispose(self):
+            """ Overloaded version of dispose() that will also dispose phosphor widget.
+            """
+            if self.phosphor:
+                try:
+                    self.phosphor.dispose()
+                    _phosphor_messaging.removeMessageHook(self.phosphor,
+                                                          self._phosphor_msg_hook)
+                except Exception as err:
+                    print(err)
+            super().dispose()
+            
         @event.connect('style')
         def __style_changed(self, *events):
             """ Emits when the style signal changes, and provides a dict with
@@ -508,8 +525,8 @@ class Widget(Model):
                 except Exception as err:
                     err.message += ' (%s)' % self.id
                     raise err
-                window.addEventListener('resize', lambda: (self.phosphor.update(),
-                                                           self._check_real_size()))
+                self._addEventListener(window, 'resize',
+                    lambda: (self.phosphor.update(), self._check_real_size()))
             if id == 'body':
                 self.outernode.classList.add('flx-main-widget')
                 window.document.title = self.title or 'Flexx app'
@@ -572,11 +589,11 @@ class Widget(Model):
         
         def _init_events(self):
             # Connect some standard events
-            self.node.addEventListener('mousedown', self.mouse_down, 0)
-            self.node.addEventListener('wheel', self.mouse_wheel, 0)
-            self.node.addEventListener('keydown', self.key_down, 0)
-            self.node.addEventListener('keyup', self.key_up, 0)
-            self.node.addEventListener('keypress', self.key_press, 0)
+            self._addEventListener(self.node, 'mousedown', self.mouse_down, 0)
+            self._addEventListener(self.node, 'wheel', self.mouse_wheel, 0)
+            self._addEventListener(self.node, 'keydown', self.key_down, 0)
+            self._addEventListener(self.node, 'keyup', self.key_up, 0)
+            self._addEventListener(self.node, 'keypress', self.key_press, 0)
             
             # Implement mouse capturing. When a mouse is pressed down on
             # a widget, it "captures" the mouse, and will continue to receive
@@ -616,11 +633,11 @@ class Widget(Model):
                         self.mouse_up(e)
 
             # Setup capturing and releasing
-            self.node.addEventListener('mousedown', capture, True)
-            self.node.addEventListener("losecapture", release)
+            self._addEventListener(self.node, 'mousedown', capture, True)
+            self._addEventListener(self.node, "losecapture", release)
             # Subscribe to normal mouse events
-            self.node.addEventListener("mousemove", mouse_inside, False)
-            self.node.addEventListener("mouseup", mouse_inside, False)
+            self._addEventListener(self.node, "mousemove", mouse_inside, False)
+            self._addEventListener(self.node, "mouseup", mouse_inside, False)
 
         @event.emitter
         def mouse_down(self, e):

--- a/flexx/ui/_widget.py
+++ b/flexx/ui/_widget.py
@@ -152,7 +152,7 @@ class Widget(Model):
             child.dispose()
         super().dispose()
         self.parent = None
-        self._children_value = ()  # tuple, to avoid triggering a reset when called twice
+        self._children_value = ()
     
     @event.connect('parent:aaa')
     def __keep_alive(self, *events):

--- a/flexx/ui/layouts/_tabs.py
+++ b/flexx/ui/layouts/_tabs.py
@@ -73,6 +73,7 @@ class TabPanel(Layout):
             self.phosphor = _phosphor_tabpanel.TabPanel()
             self.node = self.phosphor.node
             
+            # Keep track of Phosphor. Phosphor clears this ref when it is disposed.
             def _phosphor_changes_current(v, info):
                 if info.currentWidget:
                     self.current = window.flexx.instances[info.currentWidget.id]

--- a/flexx/ui/widgets/_button.py
+++ b/flexx/ui/widgets/_button.py
@@ -120,7 +120,7 @@ class Button(BaseButton):
         def _init_phosphor_and_node(self):
             self.phosphor = self._create_phosphor_widget('button')
             self.node = self.phosphor.node
-            self.node.addEventListener('click', self.mouse_click, 0)
+            self._addEventListener(self.node, 'click', self.mouse_click, 0)
 
         @event.connect('text')
         def __text_changed(self, *events):
@@ -149,7 +149,7 @@ class ToggleButton(BaseButton):
         def _init_phosphor_and_node(self):
             self.phosphor = self._create_phosphor_widget('button')
             self.node = self.phosphor.node
-            self.node.addEventListener('click', self.mouse_click, 0)
+            self._addEventListener(self.node, 'click', self.mouse_click, 0)
 
         @event.connect('text')
         def __text_changed(self, *events):
@@ -180,7 +180,7 @@ class RadioButton(BaseButton):
             self.node = p.node.childNodes[0]
             self.text_node = p.node.childNodes[1]
 
-            self.node.addEventListener('click', self._check_radio_click, 0)
+            self._addEventListener(self.node, 'click', self._check_radio_click, 0)
 
         @event.connect('parent')
         def __update_group(self, *events):
@@ -225,8 +225,8 @@ class CheckBox(BaseButton):
             self.node = p.node.childNodes[0]
             self.text_node = p.node.childNodes[1]
 
-            self.node.addEventListener('click', self.mouse_click, 0)
-            self.node.addEventListener('change', self._check_changed_from_dom, 0)
+            self._addEventListener(self.node, 'click', self.mouse_click, 0)
+            self._addEventListener(self.node, 'change', self._check_changed_from_dom, 0)
 
         @event.connect('text')
         def __text_changed(self, *events):

--- a/flexx/ui/widgets/_canvas.py
+++ b/flexx/ui/widgets/_canvas.py
@@ -39,8 +39,8 @@ class CanvasWidget(Widget):
             # Disable context menu so we can handle RMB clicks
             # Firefox is particularly stuborn with Shift+RMB, and RMB dbl click
             for ev_name in ('contextmenu', 'click', 'dblclick'):
-                window.document.addEventListener(ev_name,
-                                                 self._prevent_default_event, 0)
+                self._addEventListener(window.document, ev_name,
+                                       self._prevent_default_event, 0)
             
             # If the canvas uses the wheel event for something, you'd want to
             # disable browser-scroll when the mouse is over the canvas. But
@@ -57,7 +57,7 @@ class CanvasWidget(Widget):
                     window.flexx._wheel_timestamp = e.target.id, t1  # new scroll
             if not window.flexx._wheel_timestamp:
                 window.flexx._wheel_timestamp = 0, ''
-                window.document.addEventListener('wheel', wheel_behavior, 0)
+                self._addEventListener(window.document, 'wheel', wheel_behavior, 0)
         
         def _prevent_default_event(self, e):
             """ Prevent the default action of an event unless all modifier
@@ -66,7 +66,6 @@ class CanvasWidget(Widget):
             if e.target is self.node:
                 if not (e.altKey is True and e.ctrlKey is True and e.shiftKey is True):
                     e.preventDefault()
-                    
         
         @event.emitter
         def mouse_wheel(self, e):

--- a/flexx/ui/widgets/_color.py
+++ b/flexx/ui/widgets/_color.py
@@ -53,7 +53,7 @@ class ColorSelectWidget(Widget):
             self.phosphor = self._create_phosphor_widget('input')
             self.node = self.phosphor.node
             self.node.type = 'color'
-            self.node.addEventListener('input', self._color_changed_from_dom, 0)
+            self._addEventListener(self.node, 'input', self._color_changed_from_dom, 0)
         
         @event.connect('color')
         def _color_changed(self, *events):

--- a/flexx/ui/widgets/_dropdown.py
+++ b/flexx/ui/widgets/_dropdown.py
@@ -153,11 +153,11 @@ class BaseDropdown(Widget):
             self._strud = self.node.childNodes[4]
             
             f2 = lambda e: self._submit_text() if e.which == 13 else None
-            self._edit.addEventListener('keydown', f2, False)
-            self._edit.addEventListener('blur', self._submit_text, False)
+            self._addEventListener(self._edit, 'keydown', f2, False)
+            self._addEventListener(self._edit, 'blur', self._submit_text, False)
             
-            self._label.addEventListener('click', self._but_click, 0)
-            self._button.addEventListener('click', self._but_click, 0)
+            self._addEventListener(self._label, 'click', self._but_click, 0)
+            self._addEventListener(self._button, 'click', self._but_click, 0)
         
         @event.connect('text')
         def __on_text(self, *events):
@@ -181,7 +181,7 @@ class BaseDropdown(Widget):
             self._rect_to_check = rect
             window.setTimeout(self._check_expanded_pos, 100)
             # Collapse when the mouse is used outside the combobox (or its children)
-            window.document.addEventListener('mouseup', self._collapse_maybe, 0)
+            self._addEventListener(window.document, 'mouseup', self._collapse_maybe, 0)
             # Return rect so subclasses can use it
             return rect
         
@@ -324,7 +324,7 @@ class ComboBox(BaseDropdown):
             self._ul = window.document.createElement('ul')
             self.node.appendChild(self._ul)
             
-            self._ul.addEventListener('click', self._ul_click, 0)
+            self._addEventListener(self._ul, 'click', self._ul_click, 0)
             
         def _ul_click(self, e):
             index = e.target.index

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -98,10 +98,10 @@ class LineEdit(Widget):
             
             f1 = lambda ev: self._set_prop('user_text', self.node.value)
             f2 = lambda ev: self.submit() if ev.which == 13 else None
-            self.node.addEventListener('input', f1, False)
-            self.node.addEventListener('keydown', f2, False)
+            self._addEventListener(self.node, 'input', f1, False)
+            self._addEventListener(self.node, 'keydown', f2, False)
             #if IE10:
-            #    this.node.addEventListener('change', f1, False)
+            #    self._addEventListener(self.node, 'change', f1, False)
         
         @event.readonly
         def user_text(self, v=None):

--- a/flexx/ui/widgets/_media.py
+++ b/flexx/ui/widgets/_media.py
@@ -156,7 +156,7 @@ class YoutubeWidget(Widget):
             self.overlay_node.style.left = '0px'
             
             self.node = self.overlay_node
-            self.phosphor.node.addEventListener('mouseenter', self._show_overlay, False)
+            self._addEventListener(self.phosphor.node, 'mouseenter', self._show_overlay, False)
         
         @event.connect('size')
         def _update_canvas_size(self, *events):

--- a/flexx/ui/widgets/_media.py
+++ b/flexx/ui/widgets/_media.py
@@ -156,7 +156,7 @@ class YoutubeWidget(Widget):
             self.overlay_node.style.left = '0px'
             
             self.node = self.overlay_node
-            self._addEventListener(self.phosphor.node, 'mouseenter', self._show_overlay, False)
+            self._addEventListener(self.phosphor.node, 'mouseenter', self._show_overlay)
         
         @event.connect('size')
         def _update_canvas_size(self, *events):

--- a/flexx/ui/widgets/_slider.py
+++ b/flexx/ui/widgets/_slider.py
@@ -75,8 +75,8 @@ class Slider(Widget):
             
             self.node.type = 'range'
             f = lambda ev: self._set_prop('user_value', self.node.value)
-            self.node.addEventListener('input', f, False)
-            self.node.addEventListener('change', f, False)  # IE
+            self._addEventListener(self.node, 'input', f, False)
+            self._addEventListener(self.node, 'change', f, False)  # IE
         
         @event.readonly
         def user_value(self, v=None):

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -237,7 +237,7 @@ class TreeWidget(Widget):
     def dispose(self):
         # Note that we do not call dispose on the items like Widget does for its
         # children, because items can be in multiple items/trees at the same time.
-        self.items = []
+        self.items = ()
         super().dispose()
     
     class Both:
@@ -271,10 +271,6 @@ class TreeWidget(Widget):
             return items
     
     class JS:
-        
-        # def dispose(self):
-        #     self._items_value = []
-        #     super().dispose()
         
         def _init_phosphor_and_node(self):
             self.phosphor = self._create_phosphor_widget('div')
@@ -373,7 +369,7 @@ class TreeItem(Model):
                                'of a TreeWidget or TreeItem.')
     
     def dispose(self):
-        self.items = []
+        self.items = ()
         super().dispose()
     
     class Both:

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -234,6 +234,12 @@ class TreeWidget(Widget):
     
     """
     
+    def dispose(self):
+        # Note that we do not call dispose on the items like Widget does for its
+        # children, because items can be in multiple items/trees at the same time.
+        self.items = []
+        super().dispose()
+    
     class Both:
         
         @event.prop
@@ -265,6 +271,10 @@ class TreeWidget(Widget):
             return items
     
     class JS:
+        
+        # def dispose(self):
+        #     self._items_value = []
+        #     super().dispose()
         
         def _init_phosphor_and_node(self):
             self.phosphor = self._create_phosphor_widget('div')
@@ -362,6 +372,10 @@ class TreeItem(Model):
             raise RuntimeError('TreeItems can only be created in the context '
                                'of a TreeWidget or TreeItem.')
     
+    def dispose(self):
+        self.items = []
+        super().dispose()
+    
     class Both:
         
         @event.prop
@@ -447,8 +461,8 @@ class TreeItem(Model):
             self._title = self._row.childNodes[3]
             self._text = self._row.childNodes[4]
             
-            self._row.addEventListener('click', self._on_click)
-            self._row.addEventListener('dblclick', self.mouse_double_click)
+            self._addEventListener(self._row, 'click', self._on_click)
+            self._addEventListener(self._row, 'dblclick', self.mouse_double_click)
         
         @event.emitter
         def mouse_click(self):


### PR DESCRIPTION
In applications that dynamically create and destroy ui elements, the widgets were apparently not cleaned up correctly. There were dangling references to the objects in different places. This PR improves this.

As a reminder, this is more or less how memory management works in the current Flexx: Python is used as the "reference" object. We let the Python gc do its thing, and when it cleans something up, we call `dispose()` via `__del__`. This does some cleanup and calls `dispose()` at the JS side. One can call `dispose()` at the Py side explicitly as well. But probably better not do it at the JS side.

Measures that this PR takes:

* Add `Model._addEventListener()` that removes the event listeners in `dispose()`.
* Remove Phosphor listeners in `dispose()`.
* Dispose of objects via `flexx.dispose_object(id)` which ignores when an objet does no longer exists. So its ok to have `dispose()` called twice.
* Disposing clears the name from `flexx.instances` instead of setting it to `"disposed"`.
* When a `Model` is disposed, it wont communicate to the other side anymore.
* Widget detaches itself from parent and (implicitly from) children when disposing.
* `TreeWidget` and `TreeItem` clear their items when disposed.
