### PR TITLE
add Session.call_after_roundtrip

### DIFF
--- a/flexx/app/_session.py
+++ b/flexx/app/_session.py
@@ -94,7 +94,7 @@ class Session:
         self._model_counter = 0
         self._model_instances = weakref.WeakValueDictionary()
         self._instances_guarded = {}  # id: (ping_count, instance)
-        self._roundtrip_based_calllaters =  []  # (ping_count, callback, args, kwargs)
+        self._roundtrip_based_calllaters = []  # (ping_count, callback, args, kwargs)
         
         # While the client is not connected, we keep a queue of
         # commands, which are send to the client as soon as it connects

--- a/flexx/ui/widgets/_lineedit.py
+++ b/flexx/ui/widgets/_lineedit.py
@@ -103,6 +103,13 @@ class LineEdit(Widget):
             #if IE10:
             #    self._addEventListener(self.node, 'change', f1, False)
         
+        @event.emitter
+        def key_down(self, e):
+            # Prevent propating the key
+            ev = super().key_down(e)
+            e.stopPropagation()
+            return ev
+        
         @event.readonly
         def user_text(self, v=None):
             """ The text set by the user (updates on each keystroke). """


### PR DESCRIPTION
Adds a convenience method on `Session` to overcome jitter effects. We keep patching things up, but really, this idea of objects that exist in both Python and JS is flawed.