### PR TITLE
TreeWidget multiselect with Ctrl and Shift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ matrix:
         #
         - python: "2.7"
           env: TEST_UNIT=1 TEST_INSTALL=1
-        - python: "pypy-5.8"
-          env: TEST_UNIT=1 TEST_INSTALL=1
+        #- python: "pypy-5.7.1"
+        #  env: TEST_UNIT=1 TEST_INSTALL=1
         #
-        - python: "pypy3-5.8"
+        - python: "pypy-5.7.1"
           env: TEST_UNIT=1
         - python: "3.3"
           env: TEST_UNIT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,11 @@ matrix:
         #
         - python: "2.7"
           env: TEST_UNIT=1 TEST_INSTALL=1
-        #- python: "pypy-5.7.1"
-        #  env: TEST_UNIT=1 TEST_INSTALL=1
-        #
         - python: "pypy-5.7.1"
-          env: TEST_UNIT=1
+          env: TEST_UNIT=1 TEST_INSTALL=1
+        #
+        #- python: "pypy3-???"
+        #  env: TEST_UNIT=1
         - python: "3.3"
           env: TEST_UNIT=1
         - python: "3.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ matrix:
         #
         - python: "2.7"
           env: TEST_UNIT=1 TEST_INSTALL=1
-        - python: "pypy"
+        - python: "pypy-5.8"
           env: TEST_UNIT=1 TEST_INSTALL=1
         #
-        - python: "pypy3"
+        - python: "pypy3-5.8"
           env: TEST_UNIT=1
         - python: "3.3"
           env: TEST_UNIT=1

--- a/flexx/pyscript/tests/test_parser1.py
+++ b/flexx/pyscript/tests/test_parser1.py
@@ -8,7 +8,7 @@ def nowhitespace(s):
     return s.replace('\n', '').replace('\t', '').replace(' ', '')
 
 
-class TestParser(Parser):
+class StubParser(Parser):
     
     def function_foo_foo(self, node):
         return 'xxx'
@@ -20,11 +20,11 @@ class TestParser(Parser):
 class TestTheParser:
     
     def test_special_functions(self):
-        assert TestParser("foo_foo()").dump() == 'xxx;'
-        assert TestParser("bar_bar()").dump() == 'bar_bar();'
+        assert StubParser("foo_foo()").dump() == 'xxx;'
+        assert StubParser("bar_bar()").dump() == 'bar_bar();'
         
-        assert TestParser("xxx.bar_bar()").dump() == 'xxx;'
-        assert TestParser("xxx.foo_foo()").dump() == 'xxx.foo_foo();'
+        assert StubParser("xxx.bar_bar()").dump() == 'xxx;'
+        assert StubParser("xxx.foo_foo()").dump() == 'xxx.foo_foo();'
     
     def test_exceptions(self):
         raises(JSError, py2js, "foo(**kwargs)")

--- a/flexx/ui/widgets/_dropdown.py
+++ b/flexx/ui/widgets/_dropdown.py
@@ -307,7 +307,8 @@ class ComboBox(BaseDropdown):
         
         @event.prop
         def options(self, options=[]):
-            """ A list of tuples (key, text) representing the options.
+            """ A list of tuples (key, text) representing the options. Both
+            keys and texts are converted to strings if they are not already.
             For items that are given as a string, the key and text are the same.
             If a dict is given, it is transformed to key-text pairs.
             """

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -318,7 +318,7 @@ class TreeWidget(Widget):
                     for i in self.items:
                         i.selected = False
         
-        @event.connect('!items**.mouse_click')
+        @event.connect('!items**.mouse_click', '!items**.mouse_double_click')
         def _handle_item_clicked(self, *events):
             self._last_highlighted_hint = events[-1].source.id
             
@@ -563,7 +563,7 @@ class TreeItem(Model):
             self._text = self._row.childNodes[4]
             
             self._addEventListener(self._row, 'click', self._on_click)
-            self._addEventListener(self._row, 'dblclick', self.mouse_double_click)
+            self._addEventListener(self._row, 'dblclick', self._on_double_click)
         
         @event.emitter
         def mouse_click(self):
@@ -587,6 +587,10 @@ class TreeItem(Model):
                 self.checked = not self.checked
             else:
                 self.mouse_click()
+        
+        def _on_double_click(self, e):
+            if not (e.target is self._collapsebut or e.target is self._checkbut):
+                self.mouse_double_click()
         
         @event.connect('items')
         def __update(self, *events):

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -565,19 +565,33 @@ class TreeItem(Model):
             self._addEventListener(self._row, 'click', self._on_click)
             self._addEventListener(self._row, 'dblclick', self._on_double_click)
         
+        def _create_mouse_event(self, e):
+            # Variant of Widget._create_mouse_event(), but without position
+            modifiers = [n for n in ('Alt', 'Shift', 'Ctrl', 'Meta')
+                         if e[n.lower()+'Key']]
+            # Fix buttons
+            if e.buttons:
+                buttons_mask = reversed([c for c in e.buttons.toString(2)]).join('')
+            else:
+                buttons_mask = [e.button.toString(2)]
+            buttons = [i+1 for i in range(5) if buttons_mask[i] == '1']
+            button = {0: 1, 1: 3, 2: 2, 3: 4, 4: 5}[e.button]
+            # Create event dict
+            return dict(button=button, buttons=buttons, modifiers=modifiers)
+        
         @event.emitter
-        def mouse_click(self):
+        def mouse_click(self, e=None):
             """ Event emitted when the item is clicked on. Depending
             on the tree's max_selected, this can result in the item
             being selected/deselected.
             """
-            return {}
+            return {} if e is None else self._create_mouse_event(e)
         
         @event.emitter
         def mouse_double_click(self, e=None):
             """ Event emitted when the item is double-clicked.
             """
-            return {}
+            return {} if e is None else self._create_mouse_event(e)
         
         def _on_click(self, e):
             # Handle JS mouse click event
@@ -586,11 +600,11 @@ class TreeItem(Model):
             elif e.target is self._checkbut:
                 self.checked = not self.checked
             else:
-                self.mouse_click()
+                self.mouse_click(e)
         
         def _on_double_click(self, e):
             if not (e.target is self._collapsebut or e.target is self._checkbut):
-                self.mouse_double_click()
+                self.mouse_double_click(e)
         
         @event.connect('items')
         def __update(self, *events):

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -343,7 +343,7 @@ class TreeWidget(Widget):
                             if self._last_selected is not item:
                                 mark_selected = False
                                 for i in self.get_all_items():
-                                    if mark_selected == True:
+                                    if mark_selected == True:  # noqa - PyScript perf
                                         if i is item or i is self._last_selected:
                                             break
                                         i.selected = True

--- a/flexx/util/tests/test_import.py
+++ b/flexx/util/tests/test_import.py
@@ -13,7 +13,7 @@ from flexx.util.testing import run_tests_if_main, raises, skipif
 import flexx
 
 # https://docs.pytest.org/en/latest/skipping.html
-pytestmark = pytest.mark.skipif(
+pytestmark = skipif(
     '__pypy__' in sys.builtin_module_names and os.getenv('TRAVIS', '') == 'true',
     reason='These import tests are slow on pypy')
 

--- a/flexx/util/tests/test_import.py
+++ b/flexx/util/tests/test_import.py
@@ -8,12 +8,14 @@ import os
 import sys
 import subprocess
 
-from flexx.util.testing import run_tests_if_main, raises, skip
+from flexx.util.testing import run_tests_if_main, raises, skipif
 
 import flexx
 
-if '__pypy__' in sys.builtin_module_names and os.getenv('TRAVIS', '') == 'true':
-    skip('These import tests are slow on pypy')
+# https://docs.pytest.org/en/latest/skipping.html
+pytestmark = pytest.mark.skipif(
+    '__pypy__' in sys.builtin_module_names and os.getenv('TRAVIS', '') == 'true',
+    reason='These import tests are slow on pypy')
 
 # minimum that will be imported when importing flexx
 PROJECT_MODULE = flexx


### PR DESCRIPTION
* `TreeItem.mouse_click` and `TreeItem.mouse_double_click` events now carry more information about buttons and modifier keys (needed to implement the below).
* When `max_selected` is `<1`, one can use `Ctrl` and `Shift` to select multiple items.
* To get the old behavior, use `max_selected=1e9`.
* Doubleclicking an item selects it (previously it would just toggle on and off (or off and on).

Also fixed issues with Travis CI / Pytest / Pypy.