### PR TITLE
Tree key control improvements

### DIFF
--- a/flexx/ui/examples/control_with_keys.py
+++ b/flexx/ui/examples/control_with_keys.py
@@ -22,12 +22,19 @@ class TreeWithControls(ui.TreeWidget):
     
     class JS:
         
-        @event.connect('key_press')
+        @event.emitter
+        def key_down(self, e):
+            """Overload key_down emitter to prevent browser scroll."""
+            ev = self._create_key_event(e)
+            if ev.key.startswith('Arrow'):
+                e.preventDefault()
+            return ev
+        
+        @event.connect('key_down')
         def _handle_highlighting(self, *events):
             for ev in events:
                 if ev.modifiers:
                     continue
-                
                 if ev.key == 'Escape':
                     self.highlight_hide()
                 elif ev.key == ' ':

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -417,6 +417,13 @@ class TreeWidget(Widget):
                 _, item = all_items[index2]
                 item._row.classList.add(classname)
                 self._last_highlighted_hint = item.id
+                # Scroll into view when needed
+                y1 = item._row.offsetTop - 20
+                y2 = item._row.offsetTop + item._row.offsetHeight + 20 
+                if self.node.scrollTop > y1:
+                    self.node.scrollTop = y1
+                if self.node.scrollTop + self.node.offsetHeight < y2:
+                    self.node.scrollTop = y2 - self.node.offsetHeight
         
         def highlight_get(self):
             """ Get the "current" item. This is the currently highlighted

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -624,7 +624,7 @@ class TreeItem(Model):
             being selected/deselected.
             """
             if e is None:
-                return {button:1, buttons:[1], modifiers:[]}
+                return dict(button=1, buttons=[1], modifiers=[])
             else:
                 return self._create_mouse_event(e)
         
@@ -633,7 +633,7 @@ class TreeItem(Model):
             """ Event emitted when the item is double-clicked.
             """
             if e is None:
-                return {button:1, buttons:[1], modifiers:[]}
+                return dict(button=1, buttons=[1], modifiers=[])
             else:
                 self._create_mouse_event(e)
         

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -287,6 +287,7 @@ class TreeWidget(Widget):
             self.node.appendChild(self._ul)
         
         def init(self):
+            self._highlight_on = False
             self._last_highlighted_hint = ''
             self._last_selected = None
             
@@ -328,6 +329,8 @@ class TreeWidget(Widget):
         @event.connect('!items**.mouse_click', '!items**.mouse_double_click')
         def _handle_item_clicked(self, *events):
             self._last_highlighted_hint = events[-1].source.id
+            if self._highlight_on:  # highhlight tracks clicks
+                self.highlight_show_item(events[-1].source)
             
             if self.max_selected == 0:
                 # No selection allowed
@@ -397,12 +400,24 @@ class TreeWidget(Widget):
             """
             all_items = self._get_all_items_annotated()
             self._de_highlight_and_get_highlighted_index(all_items)
+            self._highlight_on = False
+        
+        def highlight_show_item(self, item):
+            """ Highlight the given item.
+            """
+            classname = 'highlighted-true'
+            all_items = self._get_all_items_annotated()
+            self._highlight_on = True
+            self._de_highlight_and_get_highlighted_index(all_items)
+            item._row.classList.add(classname)
+            self._last_highlighted_hint = item.id
         
         def highlight_show(self, step=0):
             """ Highlight the "current" item, optionally moving step items.
             """
             classname = 'highlighted-true'
             all_items = self._get_all_items_annotated()
+            self._highlight_on = True
             
             index1 = self._de_highlight_and_get_highlighted_index(all_items)
             index2 = 0 if index1 is None else index1 + step

--- a/flexx/ui/widgets/_tree.py
+++ b/flexx/ui/widgets/_tree.py
@@ -337,7 +337,8 @@ class TreeWidget(Widget):
                 # Select/deselect any, but only with CTRL and SHIFT
                 for ev in events:
                     item = ev.source
-                    if 'Shift' in ev.modifiers:  # Ctrl can also be in modifiers
+                    modifiers = ev.modifiers if ev.modifiers else []
+                    if 'Shift' in modifiers:  # Ctrl can also be in modifiers
                         # Select everything between last selected and current
                         if self._last_selected and self._last_selected.selected:
                             if self._last_selected is not item:
@@ -352,7 +353,7 @@ class TreeWidget(Widget):
                                             mark_selected = True
                         item.selected = True
                         self._last_selected = item
-                    elif 'Ctrl' in ev.modifiers:
+                    elif 'Ctrl' in modifiers:
                         # Toggle
                         item.selected = not item.selected
                         if item.selected:
@@ -622,13 +623,19 @@ class TreeItem(Model):
             on the tree's max_selected, this can result in the item
             being selected/deselected.
             """
-            return {} if e is None else self._create_mouse_event(e)
+            if e is None:
+                return {button:1, buttons:[1], modifiers:[]}
+            else:
+                return self._create_mouse_event(e)
         
         @event.emitter
         def mouse_double_click(self, e=None):
             """ Event emitted when the item is double-clicked.
             """
-            return {} if e is None else self._create_mouse_event(e)
+            if e is None:
+                return {button:1, buttons:[1], modifiers:[]}
+            else:
+                self._create_mouse_event(e)
         
         def _on_click(self, e):
             # Handle JS mouse click event


### PR DESCRIPTION
* Highlight tracks item clicks
* Highlighted item scrolls into view when needed
* Show how scrolling when pressing arrow keys can be turned off (though in another use-case this appraoch somehow fails)