### PR TITLE
add config tornado_debug to allow running tornado in debug mode

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -25,4 +25,7 @@ config = Config('flexx', '~appdata/.flexx.cfg',
                     'Auto-detect by default.'),
         nw_exe=('', str, 'The location of the NW.js executable. '
                 'Auto-install by default.'),
+        # tornado
+        tornado_debug=('false', bool, 'Setting the tornado application debug flag '
+                       'allows autoreload and other debugging features.'),
         )

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -79,11 +79,15 @@ class TornadoServer(AbstractServer):
                 kwargs['ssl_options'] = {}
             if 'keyfile' not in kwargs['ssl_options']:
                 kwargs['ssl_options']['keyfile'] = config.ssl_keyfile
-                
+
+        if config.tornado_debug:
+            app_kwargs = dict(debug=True)
+        else:
+            app_kwargs = dict()
         # Create tornado application
         self._app = Application([(r"/flexx/ws/(.*)", WSHandler),
                                  (r"/flexx/(.*)", MainHandler),
-                                 (r"/(.*)", AppHandler), ])
+                                 (r"/(.*)", AppHandler), ], **app_kwargs)
         # Create tornado server, bound to our own ioloop
         self._server = HTTPServer(self._app, io_loop=self._loop, **kwargs)
 


### PR DESCRIPTION
Here's a pull request for  issue #393 that I just created.   

I added a config attribute to set tornado debug mode.   

I tried some test scripts for this, but it was a little tricky reloading the app without reloading the test.

