### PR TITLE
Added config option to disable stack trace in browser window

### DIFF
--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -4,6 +4,7 @@ config = Config('flexx', '~appdata/.flexx.cfg',
 
         # General
         log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
+        browser_stacktrace=(True, bool, 'Show stack traces in browser window'),
         
         # flexx.app
         hostname=('localhost', str, 'The default hostname to serve apps.'),

--- a/flexx/_config.py
+++ b/flexx/_config.py
@@ -4,7 +4,7 @@ config = Config('flexx', '~appdata/.flexx.cfg',
 
         # General
         log_level=('info', str, 'The log level to use (DEBUG, INFO, WARNING, ERROR)'),
-        browser_stacktrace=(True, bool, 'Show stack traces in browser window'),
+        browser_stacktrace=(True, bool, 'Show server stack traces in browser window'),
         
         # flexx.app
         hostname=('localhost', str, 'The default hostname to serve apps.'),

--- a/flexx/app/_tornadoserver.py
+++ b/flexx/app/_tornadoserver.py
@@ -211,14 +211,15 @@ class FlexxHandler(RequestHandler):
         if status_code == 404:  # does not work?
             self.write('flexx.ui wants you to connect to root (404)')
         else:
-            msg = 'Flexx.ui encountered an error: <br /><br />'
-            try:  # try providing a useful message; tough luck if this fails
-                type, value, tb = kwargs['exc_info']
-                tb_str = ''.join(traceback.format_tb(tb))
-                msg += '<pre>%s\n%s</pre>' % (tb_str, str(value))
-            except Exception:
-                pass
-            self.write(msg)
+            if config.browser_stacktrace:
+                msg = 'Flexx.ui encountered an error: <br /><br />'
+                try:  # try providing a useful message; tough luck if this fails
+                    type, value, tb = kwargs['exc_info']
+                    tb_str = ''.join(traceback.format_tb(tb))
+                    msg += '<pre>%s\n%s</pre>' % (tb_str, str(value))
+                except Exception:
+                    pass
+                self.write(msg)
             super().write_error(status_code, **kwargs)
     
     def on_finish(self):


### PR DESCRIPTION
On a production server it's not desirable to show users a stack trace in case of an error. Depending on the audience this might be for user friendliness or security reasons. I feel the option should default to False, but set to True for now to maintain current behaviour.