### PR TITLE
Close websocket on unload instead of beforeunload

### DIFF
--- a/flexx/app/_clientcore.py
+++ b/flexx/app/_clientcore.py
@@ -48,7 +48,7 @@ class Flexx:
         self.instances = {}
         # Note: flexx.init() is not auto-called when Flexx is embedded
         window.addEventListener('load', self.init, False)
-        window.addEventListener('beforeunload', self.exit, False)
+        window.addEventListener('unload', self.exit, False)  # not beforeunload
     
     def init(self):
         """ Called after document is loaded. """


### PR DESCRIPTION
otherwise doing the beforeunload dialog trick will still break the app.